### PR TITLE
feat: add SQLite storage module with test isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.5] - 2025-12-18
+
+### Added
+- **SQLite Storage Module** - Centralized run history and statistics:
+  - New `storage/` module with SQLite database (`~/.editor_assistant/runs.db`)
+  - Automatic tracking of all runs, inputs, outputs, and token usage
+  - Input deduplication via content hash (same content = same input record)
+  - Many-to-many relationship: one input can be used in multiple runs
+  - Support for JSON outputs (for future structured tasks like classification)
+  
+- **New CLI Commands**:
+  - `editor-assistant history` - List recent runs with cost summary
+  - `editor-assistant history -n 50` - Show last N runs
+  - `editor-assistant history --search "arxiv"` - Search by input title
+  - `editor-assistant stats` - Usage statistics (last 7 days by default)
+  - `editor-assistant stats -d 30` - Statistics for custom period
+  - `editor-assistant show <run_id>` - Detailed view of a specific run
+  - `editor-assistant show <run_id> --output` - Include full output content
+
+### Changed
+- `MDProcessor` now automatically records all runs to SQLite database
+- Error tracking: failed runs are recorded with error messages
+- Currency symbol now matches model's pricing currency (¥ for CNY, $ for USD)
+
+### Fixed
+- **Test/Production Database Isolation**:
+  - Two separate environment variables: `EDITOR_ASSISTANT_TEST_DB_DIR` (test) and `EDITOR_ASSISTANT_DB_DIR` (prod)
+  - `conftest.py` sets test variable; production never sees it (different process)
+  - Added 53 unit tests for storage module including isolation boundary tests
+
+---
+
 ## [0.3.4] - 2025-12-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ editor-assistant process paper=paper.pdf --tasks "brief,outline"
 editor-assistant process paper=paper.pdf news=news.md --tasks "brief,outline,translate"
 ```
 
+**View Run History and Statistics:**
+
+```bash
+editor-assistant history                    # List recent runs
+editor-assistant history -n 50              # Show last 50 runs
+editor-assistant history --search "arxiv"   # Search by title
+editor-assistant stats                      # Show usage statistics (last 7 days)
+editor-assistant stats -d 30                # Show stats for last 30 days
+editor-assistant show 1                     # Show details of run #1
+editor-assistant show 1 --output            # Show full output content
+```
+
 ### Global Options
 
 - `--model`: Choose LLM model (default: deepseek-v3.2)

--- a/src/editor_assistant/storage/__init__.py
+++ b/src/editor_assistant/storage/__init__.py
@@ -1,0 +1,19 @@
+"""
+Storage module for SQLite-based run history tracking.
+
+This module provides:
+- Database initialization and connection management
+- CRUD operations for runs, inputs, outputs, and token usage
+- Query interface for history and statistics
+"""
+
+from .database import get_database_path, init_database, get_connection
+from .repository import RunRepository
+
+__all__ = [
+    "get_database_path",
+    "init_database", 
+    "get_connection",
+    "RunRepository",
+]
+

--- a/src/editor_assistant/storage/database.py
+++ b/src/editor_assistant/storage/database.py
@@ -1,0 +1,157 @@
+"""
+Database initialization and connection management.
+"""
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+import os
+
+# Default database location
+DEFAULT_DB_DIR = Path.home() / ".editor_assistant"
+DEFAULT_DB_NAME = "runs.db"
+
+# Schema version for migrations
+SCHEMA_VERSION = 1
+
+
+def get_database_path() -> Path:
+    """
+    Get the database file path, creating directory if needed.
+    
+    Environment variables (checked in order):
+    1. EDITOR_ASSISTANT_TEST_DB_DIR - For testing (highest priority)
+    2. EDITOR_ASSISTANT_DB_DIR - For production override
+    3. Default: ~/.editor_assistant/runs.db
+    """
+    # Test environment takes priority
+    test_db_dir = os.getenv("EDITOR_ASSISTANT_TEST_DB_DIR")
+    if test_db_dir:
+        db_dir = Path(test_db_dir)
+        db_dir.mkdir(parents=True, exist_ok=True)
+        return db_dir / DEFAULT_DB_NAME
+    
+    # Production: explicit override or default
+    db_dir = Path(os.getenv("EDITOR_ASSISTANT_DB_DIR", DEFAULT_DB_DIR))
+    db_dir.mkdir(parents=True, exist_ok=True)
+    return db_dir / DEFAULT_DB_NAME
+
+
+def get_connection(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    """
+    Get a database connection.
+    
+    Args:
+        db_path: Optional custom database path. Uses default if not provided.
+    
+    Returns:
+        SQLite connection with row factory enabled
+    """
+    if db_path is None:
+        db_path = get_database_path()
+    
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row  # Enable dict-like access
+    conn.execute("PRAGMA foreign_keys = ON")  # Enable foreign key constraints
+    return conn
+
+
+def init_database(db_path: Optional[Path] = None) -> None:
+    """
+    Initialize the database with schema.
+    
+    Args:
+        db_path: Optional custom database path
+    """
+    conn = get_connection(db_path)
+    cursor = conn.cursor()
+    
+    # Create tables
+    cursor.executescript(SCHEMA)
+    
+    # Set schema version
+    cursor.execute(
+        "INSERT OR REPLACE INTO schema_version (id, version) VALUES (1, ?)",
+        (SCHEMA_VERSION,)
+    )
+    
+    conn.commit()
+    conn.close()
+
+
+# Database schema
+SCHEMA = """
+-- Schema version tracking
+CREATE TABLE IF NOT EXISTS schema_version (
+    id INTEGER PRIMARY KEY,
+    version INTEGER NOT NULL
+);
+
+-- Inputs table (independent, supports deduplication)
+CREATE TABLE IF NOT EXISTS inputs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    type TEXT NOT NULL,                     -- paper, news
+    source_path TEXT,
+    title TEXT,
+    content_hash TEXT UNIQUE,               -- MD5 for deduplication
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Runs table
+CREATE TABLE IF NOT EXISTS runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    task TEXT NOT NULL,                     -- brief, outline, translate
+    model TEXT NOT NULL,                    -- deepseek-v3.2, gemini-3-flash
+    thinking_level TEXT,                    -- low, medium, high, null
+    stream INTEGER DEFAULT 1,               -- 0 or 1
+    currency TEXT DEFAULT '$',              -- pricing currency symbol
+    status TEXT DEFAULT 'pending',          -- pending, success, failed
+    error_message TEXT
+);
+
+-- Run-Input association (many-to-many)
+CREATE TABLE IF NOT EXISTS run_inputs (
+    run_id INTEGER NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    input_id INTEGER NOT NULL REFERENCES inputs(id) ON DELETE CASCADE,
+    PRIMARY KEY (run_id, input_id)
+);
+
+-- Outputs table
+CREATE TABLE IF NOT EXISTS outputs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    output_type TEXT NOT NULL,              -- main, bilingual, classification
+    content_type TEXT DEFAULT 'text',       -- text, json
+    content TEXT
+);
+
+-- Token usage table
+CREATE TABLE IF NOT EXISTS token_usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cost_input REAL DEFAULT 0,
+    cost_output REAL DEFAULT 0,
+    process_time REAL DEFAULT 0
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_runs_timestamp ON runs(timestamp);
+CREATE INDEX IF NOT EXISTS idx_runs_model ON runs(model);
+CREATE INDEX IF NOT EXISTS idx_runs_task ON runs(task);
+CREATE INDEX IF NOT EXISTS idx_inputs_hash ON inputs(content_hash);
+CREATE INDEX IF NOT EXISTS idx_outputs_run ON outputs(run_id);
+"""
+
+
+def get_schema_version(conn: sqlite3.Connection) -> int:
+    """Get current schema version."""
+    try:
+        cursor = conn.execute("SELECT version FROM schema_version WHERE id = 1")
+        row = cursor.fetchone()
+        return row[0] if row else 0
+    except sqlite3.OperationalError:
+        return 0
+

--- a/src/editor_assistant/storage/repository.py
+++ b/src/editor_assistant/storage/repository.py
@@ -1,0 +1,460 @@
+"""
+Repository for database CRUD operations.
+"""
+
+import sqlite3
+import hashlib
+from typing import List, Dict, Any, Optional
+from pathlib import Path
+from dataclasses import dataclass
+from datetime import datetime
+
+from .database import get_connection, init_database, get_database_path
+
+
+@dataclass
+class RunRecord:
+    """Represents a run record."""
+    id: int
+    timestamp: str
+    task: str
+    model: str
+    thinking_level: Optional[str]
+    stream: bool
+    status: str
+    error_message: Optional[str]
+
+
+@dataclass
+class InputRecord:
+    """Represents an input record."""
+    id: int
+    type: str
+    source_path: str
+    title: str
+    content_hash: str
+    created_at: str
+
+
+class RunRepository:
+    """Repository for managing run history in SQLite."""
+    
+    def __init__(self, db_path: Optional[Path] = None):
+        """
+        Initialize repository.
+        
+        Args:
+            db_path: Optional custom database path
+        """
+        self.db_path = db_path or get_database_path()
+        self._ensure_initialized()
+    
+    def _ensure_initialized(self) -> None:
+        """Ensure database is initialized."""
+        if not self.db_path.exists():
+            init_database(self.db_path)
+    
+    def _get_conn(self) -> sqlite3.Connection:
+        """Get database connection."""
+        return get_connection(self.db_path)
+    
+    # =========================================================================
+    # Input Operations
+    # =========================================================================
+    
+    def get_or_create_input(
+        self,
+        input_type: str,
+        source_path: str,
+        title: str,
+        content: str
+    ) -> int:
+        """
+        Get existing input by content hash or create new one.
+        
+        Args:
+            input_type: Type of input (paper, news)
+            source_path: Source file path or URL
+            title: Document title
+            content: Full content for hashing
+        
+        Returns:
+            Input ID
+        """
+        content_hash = self._hash_content(content)
+        
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        
+        # Try to find existing
+        cursor.execute(
+            "SELECT id FROM inputs WHERE content_hash = ?",
+            (content_hash,)
+        )
+        row = cursor.fetchone()
+        
+        if row:
+            conn.close()
+            return row[0]
+        
+        # Create new
+        cursor.execute(
+            """INSERT INTO inputs (type, source_path, title, content_hash)
+               VALUES (?, ?, ?, ?)""",
+            (input_type, source_path, title, content_hash)
+        )
+        input_id = cursor.lastrowid
+        conn.commit()
+        conn.close()
+        
+        return input_id
+    
+    def _hash_content(self, content: str) -> str:
+        """Generate MD5 hash of content."""
+        return hashlib.md5(content.encode('utf-8')).hexdigest()
+    
+    # =========================================================================
+    # Run Operations
+    # =========================================================================
+    
+    def create_run(
+        self,
+        task: str,
+        model: str,
+        input_ids: List[int],
+        thinking_level: Optional[str] = None,
+        stream: bool = True,
+        currency: str = "$"
+    ) -> int:
+        """
+        Create a new run record.
+        
+        Args:
+            task: Task name (brief, outline, translate)
+            model: Model name
+            input_ids: List of input IDs
+            thinking_level: Optional thinking level
+            stream: Whether streaming was used
+            currency: Pricing currency symbol
+        
+        Returns:
+            Run ID
+        """
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        
+        # Create run
+        cursor.execute(
+            """INSERT INTO runs (task, model, thinking_level, stream, currency, status)
+               VALUES (?, ?, ?, ?, ?, 'pending')""",
+            (task, model, thinking_level, 1 if stream else 0, currency)
+        )
+        run_id = cursor.lastrowid
+        
+        # Link inputs
+        for input_id in input_ids:
+            cursor.execute(
+                "INSERT INTO run_inputs (run_id, input_id) VALUES (?, ?)",
+                (run_id, input_id)
+            )
+        
+        conn.commit()
+        conn.close()
+        
+        return run_id
+    
+    def update_run_status(
+        self,
+        run_id: int,
+        status: str,
+        error_message: Optional[str] = None
+    ) -> None:
+        """
+        Update run status.
+        
+        Args:
+            run_id: Run ID
+            status: New status (success, failed)
+            error_message: Optional error message
+        """
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        
+        cursor.execute(
+            "UPDATE runs SET status = ?, error_message = ? WHERE id = ?",
+            (status, error_message, run_id)
+        )
+        
+        conn.commit()
+        conn.close()
+    
+    # =========================================================================
+    # Output Operations
+    # =========================================================================
+    
+    def add_output(
+        self,
+        run_id: int,
+        output_type: str,
+        content: str,
+        content_type: str = "text"
+    ) -> int:
+        """
+        Add output to a run.
+        
+        Args:
+            run_id: Run ID
+            output_type: Type of output (main, bilingual, classification)
+            content: Output content
+            content_type: Content type (text, json)
+        
+        Returns:
+            Output ID
+        """
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        
+        cursor.execute(
+            """INSERT INTO outputs (run_id, output_type, content_type, content)
+               VALUES (?, ?, ?, ?)""",
+            (run_id, output_type, content_type, content)
+        )
+        output_id = cursor.lastrowid
+        
+        conn.commit()
+        conn.close()
+        
+        return output_id
+    
+    # =========================================================================
+    # Token Usage Operations
+    # =========================================================================
+    
+    def add_token_usage(
+        self,
+        run_id: int,
+        input_tokens: int,
+        output_tokens: int,
+        cost_input: float,
+        cost_output: float,
+        process_time: float
+    ) -> None:
+        """
+        Add token usage for a run.
+        
+        Args:
+            run_id: Run ID
+            input_tokens: Number of input tokens
+            output_tokens: Number of output tokens
+            cost_input: Input cost
+            cost_output: Output cost
+            process_time: Processing time in seconds
+        """
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        
+        cursor.execute(
+            """INSERT INTO token_usage 
+               (run_id, input_tokens, output_tokens, cost_input, cost_output, process_time)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (run_id, input_tokens, output_tokens, cost_input, cost_output, process_time)
+        )
+        
+        conn.commit()
+        conn.close()
+    
+    # =========================================================================
+    # Query Operations
+    # =========================================================================
+    
+    def get_recent_runs(self, limit: int = 20) -> List[Dict[str, Any]]:
+        """
+        Get recent runs.
+        
+        Args:
+            limit: Maximum number of runs to return
+        
+        Returns:
+            List of run records with input titles
+        """
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        
+        cursor.execute("""
+            SELECT 
+                r.id,
+                r.timestamp,
+                r.task,
+                r.model,
+                r.status,
+                r.currency,
+                GROUP_CONCAT(i.title, ', ') as input_titles,
+                t.input_tokens,
+                t.output_tokens,
+                COALESCE(t.cost_input, 0) + COALESCE(t.cost_output, 0) as total_cost
+            FROM runs r
+            LEFT JOIN run_inputs ri ON r.id = ri.run_id
+            LEFT JOIN inputs i ON ri.input_id = i.id
+            LEFT JOIN token_usage t ON r.id = t.run_id
+            GROUP BY r.id
+            ORDER BY r.id DESC
+            LIMIT ?
+        """, (limit,))
+        
+        rows = cursor.fetchall()
+        conn.close()
+        
+        return [dict(row) for row in rows]
+    
+    def get_run_details(self, run_id: int) -> Optional[Dict[str, Any]]:
+        """
+        Get detailed information about a run.
+        
+        Args:
+            run_id: Run ID
+        
+        Returns:
+            Run details including inputs and outputs
+        """
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        
+        # Get run info
+        cursor.execute("SELECT * FROM runs WHERE id = ?", (run_id,))
+        run_row = cursor.fetchone()
+        if not run_row:
+            conn.close()
+            return None
+        
+        run = dict(run_row)
+        
+        # Get inputs
+        cursor.execute("""
+            SELECT i.* FROM inputs i
+            JOIN run_inputs ri ON i.id = ri.input_id
+            WHERE ri.run_id = ?
+        """, (run_id,))
+        run["inputs"] = [dict(row) for row in cursor.fetchall()]
+        
+        # Get outputs
+        cursor.execute(
+            "SELECT * FROM outputs WHERE run_id = ?",
+            (run_id,)
+        )
+        run["outputs"] = [dict(row) for row in cursor.fetchall()]
+        
+        # Get token usage
+        cursor.execute(
+            "SELECT * FROM token_usage WHERE run_id = ?",
+            (run_id,)
+        )
+        usage_row = cursor.fetchone()
+        run["token_usage"] = dict(usage_row) if usage_row else None
+        
+        conn.close()
+        return run
+    
+    def get_stats(self, days: int = 7) -> Dict[str, Any]:
+        """
+        Get usage statistics.
+        
+        Args:
+            days: Number of days to include
+        
+        Returns:
+            Statistics dictionary
+        """
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        
+        # Total runs
+        cursor.execute("""
+            SELECT COUNT(*) FROM runs 
+            WHERE timestamp > datetime('now', ?)
+        """, (f'-{days} days',))
+        total_runs = cursor.fetchone()[0]
+        
+        # By model
+        cursor.execute("""
+            SELECT 
+                r.model,
+                COUNT(*) as runs,
+                SUM(COALESCE(t.cost_input, 0) + COALESCE(t.cost_output, 0)) as total_cost,
+                SUM(COALESCE(t.input_tokens, 0) + COALESCE(t.output_tokens, 0)) as total_tokens
+            FROM runs r
+            LEFT JOIN token_usage t ON r.id = t.run_id
+            WHERE r.timestamp > datetime('now', ?)
+            GROUP BY r.model
+            ORDER BY runs DESC
+        """, (f'-{days} days',))
+        by_model = [dict(row) for row in cursor.fetchall()]
+        
+        # By task
+        cursor.execute("""
+            SELECT 
+                r.task,
+                COUNT(*) as runs
+            FROM runs r
+            WHERE r.timestamp > datetime('now', ?)
+            GROUP BY r.task
+            ORDER BY runs DESC
+        """, (f'-{days} days',))
+        by_task = [dict(row) for row in cursor.fetchall()]
+        
+        # Success rate
+        cursor.execute("""
+            SELECT 
+                status,
+                COUNT(*) as count
+            FROM runs
+            WHERE timestamp > datetime('now', ?)
+            GROUP BY status
+        """, (f'-{days} days',))
+        by_status = {row[0]: row[1] for row in cursor.fetchall()}
+        
+        conn.close()
+        
+        return {
+            "period_days": days,
+            "total_runs": total_runs,
+            "by_model": by_model,
+            "by_task": by_task,
+            "by_status": by_status,
+            "success_rate": by_status.get("success", 0) / total_runs if total_runs > 0 else 0
+        }
+    
+    def search_by_title(self, title_pattern: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """
+        Search runs by input title.
+        
+        Args:
+            title_pattern: Title pattern to search (supports SQL LIKE)
+            limit: Maximum results
+        
+        Returns:
+            List of matching runs
+        """
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        
+        cursor.execute("""
+            SELECT DISTINCT
+                r.id,
+                r.timestamp,
+                r.task,
+                r.model,
+                r.status,
+                i.title
+            FROM runs r
+            JOIN run_inputs ri ON r.id = ri.run_id
+            JOIN inputs i ON ri.input_id = i.id
+            WHERE i.title LIKE ?
+            ORDER BY r.timestamp DESC
+            LIMIT ?
+        """, (f'%{title_pattern}%', limit))
+        
+        rows = cursor.fetchall()
+        conn.close()
+        
+        return [dict(row) for row in rows]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,33 @@ def pytest_configure(config):
 
 
 # ============================================================================
+# DATABASE ISOLATION - CRITICAL SAFETY MEASURE
+# ============================================================================
+# This fixture runs automatically for ALL tests in the entire test session.
+# It ensures that NO test can ever touch the production database.
+
+@pytest.fixture(scope="session", autouse=True)
+def isolate_database_from_production(tmp_path_factory):
+    """
+    CRITICAL: Force ALL tests to use a temporary database directory.
+    
+    Uses EDITOR_ASSISTANT_TEST_DB_DIR (separate from production env var).
+    This prevents any test from accidentally touching ~/.editor_assistant/
+    """
+    # Create a session-wide temp directory for the database
+    test_db_dir = tmp_path_factory.mktemp("test_editor_assistant")
+    
+    # Use the TEST-specific environment variable (not the production one)
+    os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(test_db_dir)
+    
+    yield test_db_dir
+    
+    # Clean up after all tests
+    if "EDITOR_ASSISTANT_TEST_DB_DIR" in os.environ:
+        del os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"]
+
+
+# ============================================================================
 # PATH FIXTURES
 # ============================================================================
 

--- a/tests/integration/test_storage_integration.py
+++ b/tests/integration/test_storage_integration.py
@@ -1,0 +1,136 @@
+"""
+Integration tests for storage module with real LLM API calls.
+
+These tests verify that the storage module correctly records real runs.
+
+NOTE: Database isolation is handled automatically by conftest.py's
+      isolate_database_from_production fixture (session-scoped, autouse=True).
+      All tests automatically use a temporary database.
+"""
+
+import pytest
+import subprocess
+import os
+from pathlib import Path
+
+from editor_assistant.storage import RunRepository
+from editor_assistant.md_processor import MDProcessor
+from editor_assistant.data_models import MDArticle, InputType, ProcessType
+
+
+@pytest.fixture
+def sample_article(temp_dir):
+    """Create a sample article for testing."""
+    return MDArticle(
+        type=InputType.PAPER,
+        content="# Test Paper\n\nThis is a simple test paper about AI and machine learning.",
+        title="Test Paper Title",
+        source_path="https://example.com/test.html",
+        output_path=str(temp_dir / "output.md")
+    )
+
+
+class TestStorageIntegration:
+    """Integration tests for storage with real processing."""
+    
+    @pytest.mark.integration
+    @pytest.mark.slow
+    def test_real_run_recorded_in_database(self, sample_article, budget_model_name):
+        """A real LLM call should be recorded in the database."""
+        # Database is automatically isolated by conftest.py
+        processor = MDProcessor(budget_model_name, stream=False)
+        
+        # Process (this makes a real API call)
+        success = processor.process_mds([sample_article], ProcessType.BRIEF, output_to_console=False)
+        
+        # Verify run was recorded
+        runs = processor.repository.get_recent_runs()
+        
+        assert len(runs) >= 1
+        latest_run = runs[0]
+        
+        assert latest_run["task"] == "brief"
+        assert latest_run["model"] == budget_model_name
+        
+        if success:
+            assert latest_run["status"] == "success"
+            assert latest_run["total_cost"] is not None
+        else:
+            assert latest_run["status"] == "failed"
+    
+    @pytest.mark.integration
+    @pytest.mark.slow
+    def test_run_details_complete(self, sample_article, budget_model_name):
+        """Run details should include all expected fields."""
+        # Database is automatically isolated by conftest.py
+        processor = MDProcessor(budget_model_name, stream=False)
+        
+        processor.process_mds([sample_article], ProcessType.BRIEF, output_to_console=False)
+        
+        runs = processor.repository.get_recent_runs()
+        if runs:
+            run_id = runs[0]["id"]
+            details = processor.repository.get_run_details(run_id)
+            
+            # Verify structure
+            assert "id" in details
+            assert "timestamp" in details
+            assert "task" in details
+            assert "model" in details
+            assert "status" in details
+            assert "inputs" in details
+            assert "outputs" in details
+            assert "token_usage" in details
+            
+            # Verify inputs
+            assert len(details["inputs"]) == 1
+            assert details["inputs"][0]["title"] == "Test Paper Title"
+            
+            # If successful, verify outputs and usage
+            if details["status"] == "success":
+                assert len(details["outputs"]) >= 1
+                assert details["token_usage"] is not None
+                assert details["token_usage"]["input_tokens"] > 0
+
+
+class TestCLIHistoryCommands:
+    """Integration tests for CLI history commands."""
+    
+    @pytest.mark.integration
+    def test_history_command_with_data(self, isolate_database_from_production):
+        """History command should show recorded runs."""
+        # Add some data to the isolated database
+        repo = RunRepository()  # Uses isolated DB automatically
+        input_id = repo.get_or_create_input("paper", "/test.pdf", "Test Paper", "Content")
+        repo.create_run("brief", "test-model", [input_id], currency="$")
+        repo.update_run_status(1, "success")
+        
+        # Run history command with the isolated env
+        env = os.environ.copy()
+        result = subprocess.run(
+            ["editor-assistant", "history"],
+            capture_output=True,
+            text=True,
+            env=env
+        )
+        
+        # Verify command succeeds
+        assert result.returncode == 0
+    
+    @pytest.mark.integration
+    def test_stats_command_format(self):
+        """Stats command should output correct format."""
+        # Uses isolated database automatically
+        env = os.environ.copy()
+        
+        result = subprocess.run(
+            ["editor-assistant", "stats"],
+            capture_output=True,
+            text=True,
+            env=env
+        )
+        
+        assert result.returncode == 0
+        assert "Usage Statistics" in result.stdout
+        assert "Total Runs:" in result.stdout
+

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,0 +1,1018 @@
+"""
+Unit tests for the storage module.
+
+Tests database initialization, CRUD operations, and query functions.
+"""
+
+import pytest
+import os
+import threading
+
+from editor_assistant.storage.database import (
+    init_database,
+    get_connection,
+    get_database_path,
+    SCHEMA_VERSION,
+)
+from editor_assistant.storage.repository import RunRepository
+
+
+class TestDatabaseInitialization:
+    """Tests for database initialization and schema."""
+    
+    def test_init_creates_database(self, temp_dir):
+        """Database file should be created on init."""
+        db_path = temp_dir / "test.db"
+        assert not db_path.exists()
+        
+        init_database(db_path)
+        
+        assert db_path.exists()
+    
+    def test_init_creates_all_tables(self, temp_dir):
+        """All required tables should be created."""
+        db_path = temp_dir / "test.db"
+        init_database(db_path)
+        
+        conn = get_connection(db_path)
+        cursor = conn.cursor()
+        
+        # Check all tables exist
+        cursor.execute("""
+            SELECT name FROM sqlite_master 
+            WHERE type='table' ORDER BY name
+        """)
+        tables = {row[0] for row in cursor.fetchall()}
+        
+        expected_tables = {
+            'schema_version',
+            'inputs',
+            'runs',
+            'run_inputs',
+            'outputs',
+            'token_usage'
+        }
+        assert expected_tables.issubset(tables)
+        
+        conn.close()
+    
+    def test_schema_version_set(self, temp_dir):
+        """Schema version should be set after init."""
+        db_path = temp_dir / "test.db"
+        init_database(db_path)
+        
+        conn = get_connection(db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT version FROM schema_version WHERE id = 1")
+        version = cursor.fetchone()[0]
+        conn.close()
+        
+        assert version == SCHEMA_VERSION
+    
+    def test_init_idempotent(self, temp_dir):
+        """Multiple init calls should not fail."""
+        db_path = temp_dir / "test.db"
+        
+        init_database(db_path)
+        init_database(db_path)  # Should not raise
+        
+        # Data should still be intact
+        conn = get_connection(db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM schema_version")
+        count = cursor.fetchone()[0]
+        conn.close()
+        
+        assert count == 1
+    
+    def test_foreign_keys_enabled(self, temp_dir):
+        """Foreign key constraints should be enabled."""
+        db_path = temp_dir / "test.db"
+        init_database(db_path)
+        
+        conn = get_connection(db_path)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA foreign_keys")
+        fk_enabled = cursor.fetchone()[0]
+        conn.close()
+        
+        assert fk_enabled == 1
+
+
+class TestRunRepository:
+    """Tests for RunRepository CRUD operations."""
+    
+    @pytest.fixture
+    def repo(self, temp_dir):
+        """Create a repository with a temp database."""
+        db_path = temp_dir / "test.db"
+        return RunRepository(db_path=db_path)
+    
+    # =========================================================================
+    # Input Operations
+    # =========================================================================
+    
+    def test_get_or_create_input_creates_new(self, repo):
+        """Should create new input if not exists."""
+        input_id = repo.get_or_create_input(
+            input_type="paper",
+            source_path="/path/to/paper.pdf",
+            title="Test Paper",
+            content="This is the content"
+        )
+        
+        assert input_id > 0
+    
+    def test_get_or_create_input_returns_existing(self, repo):
+        """Should return existing input if content hash matches."""
+        content = "Same content for both calls"
+        
+        id1 = repo.get_or_create_input("paper", "/path1.pdf", "Title 1", content)
+        id2 = repo.get_or_create_input("paper", "/path2.pdf", "Title 2", content)
+        
+        assert id1 == id2  # Same content = same ID
+    
+    def test_content_hash_deduplication(self, repo):
+        """Different content should create different inputs."""
+        id1 = repo.get_or_create_input("paper", "/p1.pdf", "T1", "Content A")
+        id2 = repo.get_or_create_input("paper", "/p2.pdf", "T2", "Content B")
+        
+        assert id1 != id2
+    
+    def test_input_preserves_metadata(self, repo):
+        """First call's metadata should be preserved."""
+        content = "Shared content"
+        
+        repo.get_or_create_input("paper", "/first.pdf", "First Title", content)
+        
+        # Second call with different metadata
+        input_id = repo.get_or_create_input("news", "/second.md", "Second Title", content)
+        
+        # Verify original metadata is preserved
+        conn = repo._get_conn()
+        cursor = conn.cursor()
+        cursor.execute("SELECT type, source_path, title FROM inputs WHERE id = ?", (input_id,))
+        row = cursor.fetchone()
+        conn.close()
+        
+        assert row[0] == "paper"  # Original type preserved
+        assert row[1] == "/first.pdf"  # Original path preserved
+        assert row[2] == "First Title"  # Original title preserved
+    
+    # =========================================================================
+    # Run Operations
+    # =========================================================================
+    
+    def test_create_run_basic(self, repo):
+        """Should create a run with basic fields."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "Title", "Content")
+        
+        run_id = repo.create_run(
+            task="brief",
+            model="deepseek-v3.2",
+            input_ids=[input_id]
+        )
+        
+        assert run_id > 0
+    
+    def test_create_run_with_all_options(self, repo):
+        """Should create run with all optional fields."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "Title", "Content")
+        
+        run_id = repo.create_run(
+            task="outline",
+            model="gemini-3-flash",
+            input_ids=[input_id],
+            thinking_level="high",
+            stream=False,
+            currency="¥"
+        )
+        
+        # Verify all fields
+        conn = repo._get_conn()
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT task, model, thinking_level, stream, currency, status 
+            FROM runs WHERE id = ?
+        """, (run_id,))
+        row = cursor.fetchone()
+        conn.close()
+        
+        assert row[0] == "outline"
+        assert row[1] == "gemini-3-flash"
+        assert row[2] == "high"
+        assert row[3] == 0  # stream=False
+        assert row[4] == "¥"
+        assert row[5] == "pending"
+    
+    def test_create_run_links_multiple_inputs(self, repo):
+        """Should link multiple inputs to one run."""
+        id1 = repo.get_or_create_input("paper", "/p1.pdf", "Paper", "Paper content")
+        id2 = repo.get_or_create_input("news", "/n1.md", "News", "News content")
+        
+        run_id = repo.create_run(
+            task="brief",
+            model="test-model",
+            input_ids=[id1, id2]
+        )
+        
+        # Verify both inputs linked
+        conn = repo._get_conn()
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM run_inputs WHERE run_id = ?", (run_id,))
+        count = cursor.fetchone()[0]
+        conn.close()
+        
+        assert count == 2
+    
+    def test_update_run_status_success(self, repo):
+        """Should update run status to success."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("brief", "model", [input_id])
+        
+        repo.update_run_status(run_id, "success")
+        
+        details = repo.get_run_details(run_id)
+        assert details["status"] == "success"
+    
+    def test_update_run_status_failed_with_error(self, repo):
+        """Should update run status with error message."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("brief", "model", [input_id])
+        
+        repo.update_run_status(run_id, "failed", "API rate limit exceeded")
+        
+        details = repo.get_run_details(run_id)
+        assert details["status"] == "failed"
+        assert details["error_message"] == "API rate limit exceeded"
+    
+    # =========================================================================
+    # Output Operations
+    # =========================================================================
+    
+    def test_add_output_text(self, repo):
+        """Should add text output."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("brief", "model", [input_id])
+        
+        output_id = repo.add_output(run_id, "main", "Generated summary text")
+        
+        assert output_id > 0
+        
+        details = repo.get_run_details(run_id)
+        assert len(details["outputs"]) == 1
+        assert details["outputs"][0]["content_type"] == "text"
+    
+    def test_add_output_json(self, repo):
+        """Should add JSON output with correct content_type."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("classify", "model", [input_id])
+        
+        json_content = '{"keywords": ["ai", "ml"], "discipline": "computer science"}'
+        output_id = repo.add_output(run_id, "classification", json_content, "json")
+        
+        details = repo.get_run_details(run_id)
+        assert details["outputs"][0]["content_type"] == "json"
+        assert details["outputs"][0]["content"] == json_content
+    
+    def test_add_multiple_outputs(self, repo):
+        """Should support multiple outputs per run."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("translate", "model", [input_id])
+        
+        repo.add_output(run_id, "main", "Chinese translation")
+        repo.add_output(run_id, "bilingual", "Side by side translation")
+        
+        details = repo.get_run_details(run_id)
+        assert len(details["outputs"]) == 2
+        
+        output_types = {o["output_type"] for o in details["outputs"]}
+        assert output_types == {"main", "bilingual"}
+    
+    # =========================================================================
+    # Token Usage Operations
+    # =========================================================================
+    
+    def test_add_token_usage(self, repo):
+        """Should add token usage with all fields."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("brief", "model", [input_id])
+        
+        repo.add_token_usage(
+            run_id=run_id,
+            input_tokens=10000,
+            output_tokens=500,
+            cost_input=0.05,
+            cost_output=0.01,
+            process_time=15.5
+        )
+        
+        details = repo.get_run_details(run_id)
+        usage = details["token_usage"]
+        
+        assert usage["input_tokens"] == 10000
+        assert usage["output_tokens"] == 500
+        assert usage["cost_input"] == 0.05
+        assert usage["cost_output"] == 0.01
+        assert usage["process_time"] == 15.5
+    
+    # =========================================================================
+    # Query Operations
+    # =========================================================================
+    
+    def test_get_recent_runs_empty(self, repo):
+        """Should return empty list when no runs."""
+        runs = repo.get_recent_runs()
+        assert runs == []
+    
+    def test_get_recent_runs_ordered(self, repo):
+        """Should return runs in reverse ID order (proxy for chronological)."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        
+        run1 = repo.create_run("brief", "model1", [input_id])
+        run2 = repo.create_run("outline", "model2", [input_id])
+        run3 = repo.create_run("translate", "model3", [input_id])
+        
+        runs = repo.get_recent_runs(limit=10)
+        
+        # All three runs should be present
+        assert len(runs) == 3
+        
+        # IDs should be in descending order (most recent = highest ID)
+        run_ids = [r["id"] for r in runs]
+        assert run_ids == sorted(run_ids, reverse=True)
+    
+    def test_get_recent_runs_includes_currency(self, repo):
+        """Should include currency field."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        repo.create_run("brief", "deepseek-v3.2", [input_id], currency="¥")
+        
+        runs = repo.get_recent_runs()
+        assert runs[0]["currency"] == "¥"
+    
+    def test_get_run_details_not_found(self, repo):
+        """Should return None for non-existent run."""
+        details = repo.get_run_details(9999)
+        assert details is None
+    
+    def test_get_stats_empty(self, repo):
+        """Should return zero stats when no runs."""
+        stats = repo.get_stats()
+        
+        assert stats["total_runs"] == 0
+        assert stats["success_rate"] == 0
+    
+    def test_get_stats_with_data(self, repo):
+        """Should return correct statistics."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        
+        # Create 3 runs, 2 success, 1 failed
+        run1 = repo.create_run("brief", "model-a", [input_id])
+        run2 = repo.create_run("outline", "model-a", [input_id])
+        run3 = repo.create_run("brief", "model-b", [input_id])
+        
+        repo.update_run_status(run1, "success")
+        repo.update_run_status(run2, "success")
+        repo.update_run_status(run3, "failed")
+        
+        stats = repo.get_stats()
+        
+        assert stats["total_runs"] == 3
+        assert stats["by_status"]["success"] == 2
+        assert stats["by_status"]["failed"] == 1
+    
+    def test_search_by_title(self, repo):
+        """Should find runs by input title pattern."""
+        id1 = repo.get_or_create_input("paper", "/a.pdf", "Quantum Computing Paper", "C1")
+        id2 = repo.get_or_create_input("paper", "/b.pdf", "Machine Learning Paper", "C2")
+        
+        repo.create_run("brief", "model", [id1])
+        repo.create_run("brief", "model", [id2])
+        
+        results = repo.search_by_title("Quantum")
+        
+        assert len(results) == 1
+        assert "Quantum" in results[0]["title"]
+
+
+class TestManyToManyRelationship:
+    """Tests for the many-to-many relationship between runs and inputs."""
+    
+    @pytest.fixture
+    def repo(self, temp_dir):
+        db_path = temp_dir / "test.db"
+        return RunRepository(db_path=db_path)
+    
+    def test_same_input_multiple_runs(self, repo):
+        """Same input should be usable in multiple runs."""
+        # Same content = same input ID
+        content = "This is the paper content"
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "My Paper", content)
+        
+        # Three different runs with same input
+        run1 = repo.create_run("brief", "model-a", [input_id])
+        run2 = repo.create_run("outline", "model-a", [input_id])
+        run3 = repo.create_run("brief", "model-b", [input_id])
+        
+        # Verify all three runs exist
+        runs = repo.get_recent_runs()
+        assert len(runs) == 3
+        
+        # Verify only one input record
+        conn = repo._get_conn()
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM inputs")
+        input_count = cursor.fetchone()[0]
+        conn.close()
+        
+        assert input_count == 1
+    
+    def test_one_run_multiple_inputs(self, repo):
+        """One run should be able to have multiple inputs."""
+        id1 = repo.get_or_create_input("paper", "/paper.pdf", "Paper", "Paper content")
+        id2 = repo.get_or_create_input("news", "/news.md", "News 1", "News content 1")
+        id3 = repo.get_or_create_input("news", "/news2.md", "News 2", "News content 2")
+        
+        run_id = repo.create_run("brief", "model", [id1, id2, id3])
+        
+        details = repo.get_run_details(run_id)
+        assert len(details["inputs"]) == 3
+    
+    def test_query_runs_by_input(self, repo):
+        """Should be able to find all runs for a specific input."""
+        content = "Unique paper content for tracking"
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "Tracked Paper", content)
+        
+        # Multiple runs
+        repo.create_run("brief", "model1", [input_id])
+        repo.create_run("outline", "model2", [input_id])
+        
+        # Query runs by searching title
+        results = repo.search_by_title("Tracked Paper")
+        assert len(results) == 2
+    
+    def test_cascade_delete_run(self, repo):
+        """Deleting a run should cascade to run_inputs, outputs, and token_usage."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("brief", "model", [input_id])
+        repo.add_output(run_id, "main", "Output content")
+        repo.add_token_usage(run_id, 1000, 100, 0.01, 0.001, 5.0)
+        
+        # Delete the run
+        conn = repo._get_conn()
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM runs WHERE id = ?", (run_id,))
+        conn.commit()
+        
+        # Verify cascaded deletes
+        cursor.execute("SELECT COUNT(*) FROM run_inputs WHERE run_id = ?", (run_id,))
+        assert cursor.fetchone()[0] == 0
+        
+        cursor.execute("SELECT COUNT(*) FROM outputs WHERE run_id = ?", (run_id,))
+        assert cursor.fetchone()[0] == 0
+        
+        cursor.execute("SELECT COUNT(*) FROM token_usage WHERE run_id = ?", (run_id,))
+        assert cursor.fetchone()[0] == 0
+        
+        # But input should still exist
+        cursor.execute("SELECT COUNT(*) FROM inputs WHERE id = ?", (input_id,))
+        assert cursor.fetchone()[0] == 1
+        
+        conn.close()
+
+
+class TestEdgeCases:
+    """Tests for edge cases and potential issues."""
+    
+    @pytest.fixture
+    def repo(self, temp_dir):
+        db_path = temp_dir / "test.db"
+        return RunRepository(db_path=db_path)
+    
+    def test_unicode_content(self, repo):
+        """Should handle unicode content correctly."""
+        content = "这是中文内容 🎉 with émojis and spëcial çharacters"
+        input_id = repo.get_or_create_input("paper", "/中文.pdf", "中文标题", content)
+        
+        run_id = repo.create_run("brief", "model", [input_id])
+        repo.add_output(run_id, "main", "生成的中文摘要 📝")
+        
+        details = repo.get_run_details(run_id)
+        assert details["inputs"][0]["title"] == "中文标题"
+        assert "中文摘要" in details["outputs"][0]["content"]
+    
+    def test_empty_content(self, repo):
+        """Should handle empty content."""
+        input_id = repo.get_or_create_input("paper", "/empty.pdf", "Empty", "")
+        assert input_id > 0
+    
+    def test_very_long_content(self, repo):
+        """Should handle very long content."""
+        long_content = "x" * 1_000_000  # 1MB
+        input_id = repo.get_or_create_input("paper", "/big.pdf", "Big Paper", long_content)
+        
+        # Should still hash correctly
+        run_id = repo.create_run("brief", "model", [input_id])
+        details = repo.get_run_details(run_id)
+        assert details is not None
+    
+    def test_special_characters_in_path(self, repo):
+        """Should handle special characters in file paths."""
+        path = "/path/with spaces/and (parens)/file [1].pdf"
+        input_id = repo.get_or_create_input("paper", path, "Title", "Content")
+        
+        details = repo.get_run_details(
+            repo.create_run("brief", "model", [input_id])
+        )
+        assert details["inputs"][0]["source_path"] == path
+    
+    def test_null_thinking_level(self, repo):
+        """Should handle null thinking_level."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("brief", "model", [input_id], thinking_level=None)
+        
+        details = repo.get_run_details(run_id)
+        assert details["thinking_level"] is None
+    
+    def test_concurrent_reads(self, repo):
+        """Should handle concurrent read operations."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("brief", "model", [input_id])
+        repo.update_run_status(run_id, "success")
+        
+        results = []
+        errors = []
+        
+        def read_runs():
+            try:
+                runs = repo.get_recent_runs()
+                results.append(len(runs))
+            except Exception as e:
+                errors.append(str(e))
+        
+        threads = [threading.Thread(target=read_runs) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        
+        assert len(errors) == 0
+        assert all(r == 1 for r in results)
+    
+    def test_concurrent_writes_same_input(self, repo):
+        """Concurrent writes with same content - some may fail due to SQLite locking."""
+        content = "Shared content for concurrent test"
+        results = []
+        errors = []
+        
+        def create_input():
+            try:
+                input_id = repo.get_or_create_input("paper", "/p.pdf", "T", content)
+                results.append(input_id)
+            except Exception as e:
+                errors.append(str(e))
+        
+        threads = [threading.Thread(target=create_input) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        
+        # At least one should succeed
+        assert len(results) >= 1
+        # All successful results should have the same ID (content hash dedup)
+        assert len(set(results)) == 1
+        
+        # Note: SQLite has limited write concurrency, some failures are expected
+        # In production, writes are sequential (one API call at a time)
+
+
+class TestCurrencyHandling:
+    """Tests for currency symbol handling."""
+    
+    @pytest.fixture
+    def repo(self, temp_dir):
+        db_path = temp_dir / "test.db"
+        return RunRepository(db_path=db_path)
+    
+    def test_default_currency_usd(self, repo):
+        """Default currency should be USD."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("brief", "model", [input_id])
+        
+        runs = repo.get_recent_runs()
+        assert runs[0]["currency"] == "$"
+    
+    def test_custom_currency_cny(self, repo):
+        """Should support CNY currency."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        run_id = repo.create_run("brief", "deepseek-v3.2", [input_id], currency="¥")
+        
+        runs = repo.get_recent_runs()
+        assert runs[0]["currency"] == "¥"
+    
+    def test_different_currencies_different_runs(self, repo):
+        """Different runs can have different currencies."""
+        input_id = repo.get_or_create_input("paper", "/p.pdf", "T", "C")
+        
+        run1 = repo.create_run("brief", "deepseek", [input_id], currency="¥")
+        run2 = repo.create_run("brief", "gpt-4o", [input_id], currency="$")
+        
+        runs = repo.get_recent_runs()
+        currencies = {r["currency"] for r in runs}
+        assert currencies == {"¥", "$"}
+
+
+class TestDatabasePathEnvironmentVariables:
+    """Tests for database path environment variable priority."""
+    
+    def _clear_env_vars(self):
+        """Clear all database-related environment variables."""
+        for key in ["EDITOR_ASSISTANT_TEST_DB_DIR", "EDITOR_ASSISTANT_DB_DIR"]:
+            if key in os.environ:
+                del os.environ[key]
+    
+    def _save_env_vars(self):
+        """Save current environment variables."""
+        return {
+            "EDITOR_ASSISTANT_TEST_DB_DIR": os.environ.get("EDITOR_ASSISTANT_TEST_DB_DIR"),
+            "EDITOR_ASSISTANT_DB_DIR": os.environ.get("EDITOR_ASSISTANT_DB_DIR"),
+        }
+    
+    def _restore_env_vars(self, saved):
+        """Restore saved environment variables."""
+        for key, value in saved.items():
+            if value is not None:
+                os.environ[key] = value
+            elif key in os.environ:
+                del os.environ[key]
+    
+    def test_default_path_when_no_env_vars(self):
+        """Should use ~/.editor_assistant when no env vars set."""
+        saved = self._save_env_vars()
+        try:
+            self._clear_env_vars()
+            
+            path = get_database_path()
+            
+            assert ".editor_assistant" in str(path)
+            assert path.name == "runs.db"
+        finally:
+            self._restore_env_vars(saved)
+    
+    def test_test_env_var_takes_priority(self, temp_dir):
+        """EDITOR_ASSISTANT_TEST_DB_DIR should take highest priority."""
+        saved = self._save_env_vars()
+        try:
+            test_dir = temp_dir / "test_priority"
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(test_dir)
+            os.environ["EDITOR_ASSISTANT_DB_DIR"] = "/should/not/use/this"
+            
+            path = get_database_path()
+            
+            assert str(test_dir) in str(path)
+            assert "/should/not/use/this" not in str(path)
+        finally:
+            self._restore_env_vars(saved)
+    
+    def test_prod_env_var_when_no_test_var(self, temp_dir):
+        """EDITOR_ASSISTANT_DB_DIR used when TEST var not set."""
+        saved = self._save_env_vars()
+        try:
+            self._clear_env_vars()
+            prod_dir = temp_dir / "prod_override"
+            os.environ["EDITOR_ASSISTANT_DB_DIR"] = str(prod_dir)
+            
+            path = get_database_path()
+            
+            assert str(prod_dir) in str(path)
+        finally:
+            self._restore_env_vars(saved)
+    
+    def test_empty_test_var_falls_through(self, temp_dir):
+        """Empty TEST var should fall through to PROD var."""
+        saved = self._save_env_vars()
+        try:
+            self._clear_env_vars()
+            prod_dir = temp_dir / "prod_fallback"
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = ""  # Empty string
+            os.environ["EDITOR_ASSISTANT_DB_DIR"] = str(prod_dir)
+            
+            path = get_database_path()
+            
+            # Empty string is falsy, so should use PROD
+            assert str(prod_dir) in str(path)
+        finally:
+            self._restore_env_vars(saved)
+    
+    def test_creates_directory_if_not_exists(self, temp_dir):
+        """Should create database directory if it doesn't exist."""
+        saved = self._save_env_vars()
+        try:
+            new_dir = temp_dir / "new" / "nested" / "directory"
+            assert not new_dir.exists()
+            
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(new_dir)
+            
+            path = get_database_path()
+            
+            assert new_dir.exists()
+            assert path == new_dir / "runs.db"
+        finally:
+            self._restore_env_vars(saved)
+    
+    def test_test_and_prod_are_independent(self, temp_dir):
+        """Changing TEST var should not affect what PROD would use."""
+        saved = self._save_env_vars()
+        try:
+            self._clear_env_vars()
+            
+            # First call with TEST var
+            test_dir = temp_dir / "test_path"
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(test_dir)
+            path1 = get_database_path()
+            
+            # Remove TEST var, should fall back to default
+            del os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"]
+            path2 = get_database_path()
+            
+            assert str(test_dir) in str(path1)
+            assert str(test_dir) not in str(path2)
+            assert ".editor_assistant" in str(path2)
+        finally:
+            self._restore_env_vars(saved)
+    
+    def test_path_with_spaces_and_special_chars(self, temp_dir):
+        """Should handle paths with spaces and special characters."""
+        saved = self._save_env_vars()
+        try:
+            special_dir = temp_dir / "path with spaces" / "and (parens)"
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(special_dir)
+            
+            path = get_database_path()
+            
+            assert special_dir.exists()
+            assert path == special_dir / "runs.db"
+        finally:
+            self._restore_env_vars(saved)
+
+
+class TestProductionDatabaseIsolation:
+    """
+    CRITICAL: Tests to ensure testing never pollutes production database.
+    
+    These tests verify that:
+    1. Test writes go to test database, not production
+    2. Production database is never touched during tests
+    3. Test and production databases are completely separate files
+    """
+    
+    def _save_and_clear_env_vars(self):
+        """Save and clear environment variables."""
+        saved = {
+            "EDITOR_ASSISTANT_TEST_DB_DIR": os.environ.get("EDITOR_ASSISTANT_TEST_DB_DIR"),
+            "EDITOR_ASSISTANT_DB_DIR": os.environ.get("EDITOR_ASSISTANT_DB_DIR"),
+        }
+        for key in saved:
+            if key in os.environ:
+                del os.environ[key]
+        return saved
+    
+    def _restore_env_vars(self, saved):
+        """Restore saved environment variables."""
+        for key, value in saved.items():
+            if value is not None:
+                os.environ[key] = value
+            elif key in os.environ:
+                del os.environ[key]
+    
+    def test_test_database_is_different_file_from_production(self, temp_dir):
+        """Test and production databases should be completely separate files."""
+        saved = self._save_and_clear_env_vars()
+        try:
+            test_dir = temp_dir / "test_db"
+            prod_dir = temp_dir / "prod_db"
+            
+            # Set up test environment
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(test_dir)
+            test_path = get_database_path()
+            
+            # Switch to production environment
+            del os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"]
+            os.environ["EDITOR_ASSISTANT_DB_DIR"] = str(prod_dir)
+            prod_path = get_database_path()
+            
+            # They must be completely different files
+            assert test_path != prod_path
+            assert str(test_dir) in str(test_path)
+            assert str(prod_dir) in str(prod_path)
+            assert str(test_dir) not in str(prod_path)
+            assert str(prod_dir) not in str(test_path)
+        finally:
+            self._restore_env_vars(saved)
+    
+    def test_writes_to_test_db_do_not_appear_in_prod_db(self, temp_dir):
+        """Data written to test database must not appear in production database."""
+        saved = self._save_and_clear_env_vars()
+        try:
+            test_dir = temp_dir / "test_isolated"
+            prod_dir = temp_dir / "prod_isolated"
+            
+            # Write to test database
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(test_dir)
+            test_repo = RunRepository()
+            input_id = test_repo.get_or_create_input(
+                "paper", "/test.pdf", "TEST ONLY TITLE", "test content"
+            )
+            test_repo.create_run("brief", "test-model", [input_id])
+            
+            # Verify data exists in test database
+            test_runs = test_repo.get_recent_runs()
+            assert len(test_runs) == 1
+            assert test_runs[0]["input_titles"] == "TEST ONLY TITLE"
+            
+            # Switch to production database
+            del os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"]
+            os.environ["EDITOR_ASSISTANT_DB_DIR"] = str(prod_dir)
+            prod_repo = RunRepository()
+            
+            # Production database should be empty
+            prod_runs = prod_repo.get_recent_runs()
+            assert len(prod_runs) == 0
+            
+            # Search should not find the test data
+            search_results = prod_repo.search_by_title("TEST ONLY")
+            assert len(search_results) == 0
+        finally:
+            self._restore_env_vars(saved)
+    
+    def test_production_data_not_visible_in_test_environment(self, temp_dir):
+        """Data in production database should not be visible in test environment."""
+        saved = self._save_and_clear_env_vars()
+        try:
+            test_dir = temp_dir / "test_env"
+            prod_dir = temp_dir / "prod_env"
+            
+            # First, write to production database
+            os.environ["EDITOR_ASSISTANT_DB_DIR"] = str(prod_dir)
+            prod_repo = RunRepository()
+            input_id = prod_repo.get_or_create_input(
+                "paper", "/prod.pdf", "PRODUCTION DATA", "prod content"
+            )
+            prod_repo.create_run("outline", "prod-model", [input_id])
+            
+            # Verify production has data
+            assert len(prod_repo.get_recent_runs()) == 1
+            
+            # Now switch to test environment
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(test_dir)
+            test_repo = RunRepository()
+            
+            # Test environment should NOT see production data
+            test_runs = test_repo.get_recent_runs()
+            assert len(test_runs) == 0
+            
+            search_results = test_repo.search_by_title("PRODUCTION")
+            assert len(search_results) == 0
+        finally:
+            self._restore_env_vars(saved)
+    
+    def test_conftest_isolation_fixture_works(self, isolate_database_from_production):
+        """The conftest fixture should properly isolate the database."""
+        # isolate_database_from_production is the session fixture from conftest.py
+        # It should have set EDITOR_ASSISTANT_TEST_DB_DIR
+        
+        assert "EDITOR_ASSISTANT_TEST_DB_DIR" in os.environ
+        test_db_dir = os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"]
+        
+        # The path should be in a temp directory, not ~/.editor_assistant
+        db_path = get_database_path()
+        assert ".editor_assistant" not in str(db_path)
+        assert test_db_dir in str(db_path)
+    
+    def test_repository_uses_isolated_database_during_tests(self, isolate_database_from_production):
+        """RunRepository should use the isolated test database during tests."""
+        # Create a repository (should use the isolated database)
+        repo = RunRepository()
+        
+        # Write some data
+        input_id = repo.get_or_create_input(
+            "paper", "/isolation_test.pdf", "ISOLATION TEST", "content"
+        )
+        run_id = repo.create_run("translate", "isolation-model", [input_id])
+        
+        # The database file should be in the temp directory
+        db_path = repo.db_path
+        assert ".editor_assistant" not in str(db_path)
+        
+        # The data should be there
+        runs = repo.get_recent_runs()
+        assert any("ISOLATION TEST" in (r.get("input_titles") or "") for r in runs)
+    
+    def test_concurrent_test_and_production_processes(self, temp_dir):
+        """
+        Simulate: test is running while someone triggers production.
+        
+        Scenario:
+        - Process A (pytest): has EDITOR_ASSISTANT_TEST_DB_DIR set
+        - Process B (production): no test env var, uses default/PROD path
+        
+        They should write to completely different databases.
+        """
+        saved = {
+            "EDITOR_ASSISTANT_TEST_DB_DIR": os.environ.get("EDITOR_ASSISTANT_TEST_DB_DIR"),
+            "EDITOR_ASSISTANT_DB_DIR": os.environ.get("EDITOR_ASSISTANT_DB_DIR"),
+        }
+        try:
+            test_dir = temp_dir / "concurrent_test"
+            prod_dir = temp_dir / "concurrent_prod"
+            
+            # === Simulate Test Process ===
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(test_dir)
+            if "EDITOR_ASSISTANT_DB_DIR" in os.environ:
+                del os.environ["EDITOR_ASSISTANT_DB_DIR"]
+            
+            test_repo = RunRepository()
+            test_input_id = test_repo.get_or_create_input(
+                "paper", "/test.pdf", "FROM_TEST_PROCESS", "test"
+            )
+            test_repo.create_run("brief", "test-model", [test_input_id])
+            test_path = test_repo.db_path
+            
+            # === Simulate Production Process (different env) ===
+            # Production process would NOT have TEST_DB_DIR set
+            del os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"]
+            os.environ["EDITOR_ASSISTANT_DB_DIR"] = str(prod_dir)
+            
+            prod_repo = RunRepository()
+            prod_input_id = prod_repo.get_or_create_input(
+                "paper", "/prod.pdf", "FROM_PROD_PROCESS", "prod"
+            )
+            prod_repo.create_run("outline", "prod-model", [prod_input_id])
+            prod_path = prod_repo.db_path
+            
+            # === Verify Complete Isolation ===
+            # Different database files
+            assert test_path != prod_path
+            assert str(test_dir) in str(test_path)
+            assert str(prod_dir) in str(prod_path)
+            
+            # Test data only in test db
+            os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"] = str(test_dir)
+            if "EDITOR_ASSISTANT_DB_DIR" in os.environ:
+                del os.environ["EDITOR_ASSISTANT_DB_DIR"]
+            test_repo2 = RunRepository()
+            test_runs = test_repo2.get_recent_runs()
+            assert len(test_runs) == 1
+            assert "FROM_TEST_PROCESS" in test_runs[0].get("input_titles", "")
+            assert "FROM_PROD_PROCESS" not in test_runs[0].get("input_titles", "")
+            
+            # Prod data only in prod db
+            del os.environ["EDITOR_ASSISTANT_TEST_DB_DIR"]
+            os.environ["EDITOR_ASSISTANT_DB_DIR"] = str(prod_dir)
+            prod_repo2 = RunRepository()
+            prod_runs = prod_repo2.get_recent_runs()
+            assert len(prod_runs) == 1
+            assert "FROM_PROD_PROCESS" in prod_runs[0].get("input_titles", "")
+            assert "FROM_TEST_PROCESS" not in prod_runs[0].get("input_titles", "")
+            
+        finally:
+            # Restore
+            for key, value in saved.items():
+                if value is not None:
+                    os.environ[key] = value
+                elif key in os.environ:
+                    del os.environ[key]
+    
+    def test_production_unaffected_by_test_env_var_in_different_process(self, temp_dir):
+        """
+        Real scenario: pytest sets TEST_DB_DIR, but production CLI in another
+        terminal does NOT see this env var (different process).
+        
+        This test verifies the logic that production code without TEST_DB_DIR
+        will use the production path.
+        """
+        saved = {
+            "EDITOR_ASSISTANT_TEST_DB_DIR": os.environ.get("EDITOR_ASSISTANT_TEST_DB_DIR"),
+            "EDITOR_ASSISTANT_DB_DIR": os.environ.get("EDITOR_ASSISTANT_DB_DIR"),
+        }
+        try:
+            # === Scenario: Production process (no TEST_DB_DIR) ===
+            # Clear both env vars to simulate fresh production process
+            for key in ["EDITOR_ASSISTANT_TEST_DB_DIR", "EDITOR_ASSISTANT_DB_DIR"]:
+                if key in os.environ:
+                    del os.environ[key]
+            
+            prod_path = get_database_path()
+            
+            # Production should use default ~/.editor_assistant path
+            assert ".editor_assistant" in str(prod_path)
+            assert "test" not in str(prod_path).lower()
+            
+        finally:
+            for key, value in saved.items():
+                if value is not None:
+                    os.environ[key] = value
+                elif key in os.environ:
+                    del os.environ[key]
+


### PR DESCRIPTION
Storage Module:
- New storage/ module with database.py and repository.py
- SQLite database at ~/.editor_assistant/runs.db
- Automatic tracking of runs, inputs, outputs, token usage
- Input deduplication via content hash
- Many-to-many relationship (one input → multiple runs)
- Currency symbol support per model

CLI Commands:
- editor-assistant history [-n N] [--search PATTERN]
- editor-assistant stats [-d DAYS]
- editor-assistant show RUN_ID [--output]

Test Isolation:
- Two env vars: EDITOR_ASSISTANT_TEST_DB_DIR (test), EDITOR_ASSISTANT_DB_DIR (prod)
- conftest.py auto-sets test var; prod never sees it
- 53 unit tests including isolation boundary tests

Docs:
- Updated DEVELOPER.md, README.md, CHANGELOG.md, TODO.md