### PR TITLE
feat(models): add GLM-4.7 + Gemini free tier; integration model toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 - **GLM-4.7 Support**: Added Zhipu's latest GLM-4.7 model
   - Native Zhipu: `--model glm-4.7`
   - OpenRouter: `--model glm-4.7-or` (now default)
-  - 200K context window, 128K+ max output
+  - 200K context window; native max output 128K, OpenRouter pinned route max output 65,536
 - **Gemini Free Tier**: Added support for Gemini Free Tier API
   - `--model gemini-2.5-flash-free` and `--model gemini-2.5-flash-lite-free`
   - Uses `GEMINI_FT_API_KEY` environment variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,12 @@ All notable changes to this project will be documented in this file.
   - OpenRouter: `--model glm-4.7-or` (now default)
   - 200K context window, 128K+ max output
 - **Gemini Free Tier**: Added support for Gemini Free Tier API
-  - `--model gemini-3-flash-free` and `--model gemini-3-pro-free`
+  - `--model gemini-2.5-flash-free` and `--model gemini-2.5-flash-lite-free`
   - Uses `GEMINI_FT_API_KEY` environment variable
-  - Conservative rate limiting (5 RPM) for stability
+  - Rate limits: 5 RPM / 250K TPM / 20 RPD (from AI Studio)
 - **Integration Test Options**: `pytest --integration-model` to select test model
   - `base` (default): deepseek-v3.2
-  - `advanced`: gemini-3-flash-free
+  - `advanced`: gemini-2.5-flash-free
 
 ### Changed
 - **Default Model**: Changed from `deepseek-v3.2` to `glm-4.7-or`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,20 @@ All notable changes to this project will be documented in this file.
   - Supports JSON and CSV formats (auto-detected from file extension)
   - Includes full run details: inputs, outputs, token usage
   - `--limit` flag to limit number of exported runs
+- **GLM-4.7 Support**: Added Zhipu's latest GLM-4.7 model
+  - Native Zhipu: `--model glm-4.7`
+  - OpenRouter: `--model glm-4.7-or` (now default)
+  - 200K context window, 128K+ max output
+- **Gemini Free Tier**: Added support for Gemini Free Tier API
+  - `--model gemini-3-flash-free` and `--model gemini-3-pro-free`
+  - Uses `GEMINI_FT_API_KEY` environment variable
+  - Conservative rate limiting (5 RPM) for stability
+- **Integration Test Options**: `pytest --integration-model` to select test model
+  - `base` (default): deepseek-v3.2
+  - `advanced`: gemini-3-flash-free
 
 ### Changed
+- **Default Model**: Changed from `deepseek-v3.2` to `glm-4.7-or`
 - **Model Config Refactor**: YAML is now the single source of truth for model/provider configuration.
   - Removed hardcoded `LLMModel` and `ServiceProvider` enums from `set_llm.py`
   - Model list is now dynamically loaded from `llm_config.yml`

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,28 @@
 # Editor Assistant - TODO
 
-> 最后更新: 2025-12-31
+> 最后更新: 2026-01-04
 > 
 > 此文件是当前待完成任务的执行清单，与 [FUTURE_ROADMAP.md](./FUTURE_ROADMAP.md) 保持同步。
 
 ---
 
 ## 🔄 Phase 1: 当前待完成
+
+### ~~0. GLM-4.7 + Gemini Free Tier~~ ✅ 已完成
+**优先级: 最高 | 完成时间: 2026-01-04**
+
+- [x] GLM-4.7 模型支持
+  - [x] zhipu native: `glm-4.7`
+  - [x] zhipu-openrouter: `glm-4.7-or`
+  - [x] 设置 `glm-4.7-or` 为默认模型
+- [x] Gemini Free Tier 支持
+  - [x] 新增 `gemini-free` provider
+  - [x] 模型: `gemini-3-flash-free`, `gemini-3-pro-free`
+  - [x] 保守 rate limiting (5 RPM)
+- [x] Integration 测试选项
+  - [x] `--integration-model base` (deepseek-v3.2, 默认)
+  - [x] `--integration-model advanced` (gemini-3-flash-free)
+- [ ] 待测试后更新 rate limit 配置
 
 ### ~~1. Resume Capability & Export~~ ✅ 已完成
 **优先级: 高 | 预计工作量: 1天**

--- a/TODO.md
+++ b/TODO.md
@@ -17,12 +17,11 @@
   - [x] 设置 `glm-4.7-or` 为默认模型
 - [x] Gemini Free Tier 支持
   - [x] 新增 `gemini-free` provider
-  - [x] 模型: `gemini-3-flash-free`, `gemini-3-pro-free`
-  - [x] 保守 rate limiting (5 RPM)
+  - [x] 模型: `gemini-2.5-flash-free`, `gemini-2.5-flash-lite-free`
+  - [x] Rate limit: 5 RPM, 250K TPM, 20 RPD (from AI Studio)
 - [x] Integration 测试选项
   - [x] `--integration-model base` (deepseek-v3.2, 默认)
-  - [x] `--integration-model advanced` (gemini-3-flash-free)
-- [ ] 待测试后更新 rate limit 配置
+  - [x] `--integration-model advanced` (gemini-2.5-flash-free)
 
 ### ~~1. Resume Capability & Export~~ ✅ 已完成
 **优先级: 高 | 预计工作量: 1天**

--- a/docs/design_docs/rfc_glm47_gemini_free.md
+++ b/docs/design_docs/rfc_glm47_gemini_free.md
@@ -1,0 +1,306 @@
+# RFC: GLM-4.7 支持 + Gemini Free Tier 集成
+
+> 创建日期: 2025-01-04
+> 状态: ✅ Implemented
+> 更新: 2025-01-04 - 完成实现
+
+---
+
+## 1. 概述
+
+本 RFC 描述两个高优先级功能的实现方案：
+1. **GLM-4.7 模型支持** - 在 zhipu native 和 OpenRouter 场景下支持最新的 GLM-4.7 模型
+2. **Gemini Free Tier API** - 支持 Gemini 免费层级 API，用于实际调用和 integration 测试
+
+---
+
+## 2. GLM-4.7 模型支持
+
+### 2.1 背景
+
+智谱 AI 于 2025 年 12 月 23 日发布了 GLM-4.7 模型，主要提升：
+- **编码能力**: SWE-bench Verified 得分 73.8%（开源模型 SOTA）
+- **推理能力**: HLE 测试得分 42.8%，超过 GPT-5.1
+- **工具调用**: BrowseComp 得分 67.5%
+- **上下文窗口**: 200K tokens (比 glm-4.6 的 128K 更大)
+- **最大输出**: 128K tokens (比 glm-4.6 的 96K 更大)
+
+### 2.2 配置信息
+
+#### Zhipu Native
+
+| 参数 | 值 | 备注 |
+|------|-----|------|
+| **模型 ID** | `glm-4.7` | |
+| **API URL** | `https://open.bigmodel.cn/api/paas/v4/chat/completions` | 与现有 zhipu provider 相同 |
+| **Context Window** | 200,000 tokens | |
+| **Max Output** | 128,000 tokens | |
+| **定价 (per 1M tokens)** | input: $0.11, output: $0.11 | 根据官方信息 |
+
+#### OpenRouter
+
+参考: https://openrouter.ai/z-ai/glm-4.7
+
+| 参数 | 值 | 备注 |
+|------|-----|------|
+| **模型 ID** | `z-ai/glm-4.7` | |
+| **命名** | `glm-4.7-or` | 遵循现有 `-or` 后缀规范 |
+| **定价 (per 1M tokens)** | input: $0.60, output: $2.20 | Z.AI provider (最高) |
+| **Context Window** | 200,000 tokens | |
+| **Max Output** | 128,000 tokens | |
+
+### 2.3 默认模型切换
+
+将 `cli.py` 中的 `DEFAULT_MODEL` 从 `deepseek-v3.2` 改为 `glm-4.7-or`。
+
+**理由：**
+- GLM-4.7 性能更优（开源 SOTA）
+- 通过 OpenRouter 调用更稳定
+- 价格合理
+
+### 2.4 llm_config.yml 变更
+
+```yaml
+# 更新 zhipu provider - 添加 glm-4.7
+zhipu:
+  api_key_env_var: "ZHIPU_API_KEY"
+  api_base_url: "https://open.bigmodel.cn/api/paas/v4/chat/completions"
+  temperature: 0.6
+  max_tokens: 128000  # 更新为 128K
+  context_window: 200000  # 更新为 200K
+  pricing_currency: "$"
+  models:
+    glm-4.5:
+      id: "glm-4.5"
+      pricing: {input: 0.60, output: 2.20}
+    glm-4.6:
+      id: "glm-4.6"
+      pricing: {input: 0.60, output: 2.20}
+    glm-4.7:  # 新增
+      id: "glm-4.7"
+      pricing: {input: 0.11, output: 0.11}
+
+# 更新 zhipu-openrouter provider - 添加 glm-4.7-or
+zhipu-openrouter:
+  # ... 保持其他配置不变 ...
+  max_tokens: 128000  # 更新
+  context_window: 200000  # 更新
+  models:
+    glm-4.5-or:
+      id: "z-ai/glm-4.5"
+      pricing: {input: 0.38, output: 1.60}
+    glm-4.6-or:
+      id: "z-ai/glm-4.6"
+      pricing: {input: 0.60, output: 2.00}
+    glm-4.7-or:  # 新增 - 按最高 provider 价格 (Z.AI)
+      id: "z-ai/glm-4.7"
+      pricing: {input: 0.60, output: 2.20}
+```
+
+---
+
+## 3. Gemini Free Tier API
+
+### 3.1 背景
+
+Google 提供 Gemini API 的免费层级，允许有限的免费调用。这对于：
+- 实际使用低成本调用
+- Integration 测试高级模型功能（不只是 deepseek/glm）
+- 降低开发和测试成本
+
+### 3.2 支持的模型
+
+仍然支持最先进的 **3 系列模型**：
+- `gemini-3-flash-free` (gemini-3-flash-preview)
+- `gemini-3-pro-free` (gemini-3-pro-preview)
+
+### 3.3 Free Tier 限制
+
+不同模型的 RPM/RPD 限制不同，Pro 限制高于 Flash。
+
+由于尚未调用过 API，具体限制暂时不可见。**采用非常保守的初始配置**，待测试成功后根据 AI Studio 数据更新。
+
+#### 初始保守配置
+
+| 模型 | RPM (保守) | min_interval_seconds | 备注 |
+|------|------------|---------------------|------|
+| gemini-3-flash-free | 5 | 12.0 | 非常保守，待测试后调整 |
+| gemini-3-pro-free | 2 | 30.0 | Pro 限制可能更严格，更保守 |
+
+### 3.4 llm_config.yml 变更
+
+```yaml
+# 新增 gemini-free provider
+gemini-free:
+  api_key_env_var: "GEMINI_FT_API_KEY"
+  api_base_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+  temperature: 1.0
+  max_tokens: 65536  # 与付费版相同，如有限制后续调整
+  context_window: 1000000
+  pricing_currency: "$"
+  # 非常保守的 rate limiting - 待测试后调整
+  rate_limit:
+    min_interval_seconds: 12.0  # 5 RPM for flash
+    max_requests_per_minute: 5
+  models:
+    gemini-3-flash-free:
+      id: "gemini-3-flash-preview"
+      pricing: { input: 0.0, output: 0.0 }
+    gemini-3-pro-free:
+      id: "gemini-3-pro-preview"
+      pricing: { input: 0.0, output: 0.0 }
+      # Pro 可能需要更严格的 rate limit，但 per-model rate limit 暂不支持
+      # 如需独立控制，可创建 gemini-free-pro provider
+```
+
+### 3.5 后续更新
+
+测试调用成功后，从 AI Studio 获取实际限制数据，更新：
+- `min_interval_seconds`
+- `max_requests_per_minute`
+- 如有需要，`max_tokens` 限制
+
+---
+
+## 4. Integration 测试改进
+
+### 4.1 需求
+
+提供两个模型选项供用户选择：
+- **基础模型**: `deepseek-v3.2` (默认)
+- **高级模型**: `gemini-3-flash-free`
+
+### 4.2 实现方案
+
+#### conftest.py 修改
+
+```python
+# tests/conftest.py
+
+def pytest_addoption(parser):
+    """Add command-line options for integration tests."""
+    parser.addoption(
+        "--integration-model",
+        action="store",
+        default="basic",
+        choices=["basic", "advanced"],
+        help="Integration test model: basic (deepseek-v3.2) or advanced (gemini-3-flash-free)"
+    )
+
+@pytest.fixture
+def integration_model_name(request):
+    """Get the model name for integration tests based on CLI option."""
+    choice = request.config.getoption("--integration-model")
+    if choice == "advanced":
+        return "gemini-3-flash-free"
+    return "deepseek-v3.2"  # default: basic
+```
+
+#### 使用示例
+
+```bash
+# 使用基础模型（默认）
+pytest tests/integration/ -m integration
+
+# 使用高级模型（Gemini Free Tier）
+pytest tests/integration/ -m integration --integration-model advanced
+```
+
+---
+
+## 5. 实现步骤
+
+### Phase 1: GLM-4.7 支持 ✅
+
+1. [x] 更新 `llm_config.yml`
+   - 添加 `glm-4.7` 到 zhipu provider
+   - 添加 `glm-4.7-or` 到 zhipu-openrouter provider
+   - 更新 context_window 和 max_tokens
+
+2. [x] 更新 `cli.py`
+   - `DEFAULT_MODEL = "glm-4.7-or"`
+
+3. [ ] 测试验证
+   - zhipu native 调用
+   - OpenRouter 调用
+
+### Phase 2: Gemini Free Tier ✅
+
+1. [x] 更新 `llm_config.yml`
+   - 添加 `gemini-free` provider
+   - 配置保守的 rate limiting
+
+2. [ ] 测试验证
+   - 使用 `GEMINI_FT_API_KEY` 调用
+   - 确认 rate limiting 工作
+
+3. [ ] 后续：根据 AI Studio 数据更新 rate limit 配置
+
+### Phase 3: Integration 测试改进 ✅
+
+1. [x] 更新 `conftest.py`
+   - 添加 `--integration-model` CLI 选项
+   - 添加 `budget_model_name` fixture (动态选择模型)
+
+2. [ ] 更新现有 integration 测试
+   - 使用 `budget_model_name` fixture
+
+3. [ ] 文档更新
+   - tests/README.md 说明新选项
+
+---
+
+## 6. 变更范围
+
+| 文件 | 变更类型 | 描述 |
+|------|----------|------|
+| `llm_config.yml` | 修改 | 添加 glm-4.7, glm-4.7-or, gemini-free provider |
+| `cli.py` | 修改 | DEFAULT_MODEL = "glm-4.7-or" |
+| `tests/conftest.py` | 修改 | 添加 --integration-model 选项 |
+| `tests/README.md` | 修改 | 文档更新 |
+| `TODO.md` | 修改 | 添加新任务 |
+| `CHANGELOG.md` | 修改 | 记录变更 |
+
+---
+
+## 7. 时间估算
+
+| 任务 | 估算 |
+|------|------|
+| GLM-4.7 配置 + 测试 | 0.5 天 |
+| Gemini Free Tier 配置 + 测试 | 0.5 天 |
+| Integration 测试改进 | 0.5 天 |
+| **总计** | **1.5 天** |
+
+---
+
+## 8. 价格确认
+
+GLM-4.7 OpenRouter 价格已确认（Z.AI provider - 最高价格）：
+
+| 参数 | 值 |
+|------|-----|
+| Input pricing (per 1M) | $0.60 |
+| Output pricing (per 1M) | $2.20 |
+| Cache Read (per 1M) | $0.11 |
+
+---
+
+## 附录：测试命令
+
+```bash
+# 测试 GLM-4.7 native
+editor-assistant brief paper=test.pdf --model glm-4.7
+
+# 测试 GLM-4.7 OpenRouter
+editor-assistant brief paper=test.pdf --model glm-4.7-or
+
+# 测试 Gemini Free Tier
+editor-assistant brief paper=test.pdf --model gemini-3-flash-free
+
+# Integration 测试（基础模型）
+pytest tests/integration/ -m integration
+
+# Integration 测试（高级模型）
+pytest tests/integration/ -m integration --integration-model advanced
+```

--- a/docs/design_docs/rfc_glm47_gemini_free.md
+++ b/docs/design_docs/rfc_glm47_gemini_free.md
@@ -110,22 +110,18 @@ Google 提供 Gemini API 的免费层级，允许有限的免费调用。这对�
 
 ### 3.2 支持的模型
 
-仍然支持最先进的 **3 系列模型**：
-- `gemini-3-flash-free` (gemini-3-flash-preview)
-- `gemini-3-pro-free` (gemini-3-pro-preview)
+**Free Tier 不支持 3-pro**，使用 2.5 系列：
+- `gemini-2.5-flash-free` (gemini-2.5-flash)
+- `gemini-2.5-flash-lite-free` (gemini-2.5-flash-lite)
 
 ### 3.3 Free Tier 限制
 
-不同模型的 RPM/RPD 限制不同，Pro 限制高于 Flash。
+从 AI Studio 获取的实际限制 (2026-01-04)：
 
-由于尚未调用过 API，具体限制暂时不可见。**采用非常保守的初始配置**，待测试成功后根据 AI Studio 数据更新。
-
-#### 初始保守配置
-
-| 模型 | RPM (保守) | min_interval_seconds | 备注 |
-|------|------------|---------------------|------|
-| gemini-3-flash-free | 5 | 12.0 | 非常保守，待测试后调整 |
-| gemini-3-pro-free | 2 | 30.0 | Pro 限制可能更严格，更保守 |
+| 模型 | RPM | TPM | RPD |
+|------|-----|-----|-----|
+| gemini-2.5-flash | 5 | 250K | 20 |
+| gemini-2.5-flash-lite | 10 | 250K | 20 |
 
 ### 3.4 llm_config.yml 变更
 
@@ -135,22 +131,19 @@ gemini-free:
   api_key_env_var: "GEMINI_FT_API_KEY"
   api_base_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
   temperature: 1.0
-  max_tokens: 65536  # 与付费版相同，如有限制后续调整
+  max_tokens: 65536
   context_window: 1000000
   pricing_currency: "$"
-  # 非常保守的 rate limiting - 待测试后调整
   rate_limit:
-    min_interval_seconds: 12.0  # 5 RPM for flash
+    min_interval_seconds: 12.0  # 5 RPM
     max_requests_per_minute: 5
   models:
-    gemini-3-flash-free:
-      id: "gemini-3-flash-preview"
+    gemini-2.5-flash-free:
+      id: "gemini-2.5-flash"
       pricing: { input: 0.0, output: 0.0 }
-    gemini-3-pro-free:
-      id: "gemini-3-pro-preview"
+    gemini-2.5-flash-lite-free:
+      id: "gemini-2.5-flash-lite"
       pricing: { input: 0.0, output: 0.0 }
-      # Pro 可能需要更严格的 rate limit，但 per-model rate limit 暂不支持
-      # 如需独立控制，可创建 gemini-free-pro provider
 ```
 
 ### 3.5 后续更新

--- a/src/editor_assistant/cli.py
+++ b/src/editor_assistant/cli.py
@@ -29,7 +29,7 @@ from .config.logging_config import progress
 from .storage import RunRepository
 
 
-DEFAULT_MODEL = "deepseek-v3.2"
+DEFAULT_MODEL = "glm-4.7-or"
 
 
 def add_common_arguments(parser):

--- a/src/editor_assistant/config/llm_config.yml
+++ b/src/editor_assistant/config/llm_config.yml
@@ -148,9 +148,17 @@ zhipu-openrouter:
   api_key_env_var: "ZHIPU_API_KEY_OPENROUTER"
   api_base_url: *openrouter_endpoint
   temperature: 0.6
-  max_tokens: 131100  # GLM-4.7 max output on OpenRouter
+  # Note: when pinning provider routing (see request_overrides below), OpenRouter
+  # will return 404 ("No allowed providers...") if max_tokens exceeds the pinned
+  # provider's max output. GLM-4.7 max output shown on OpenRouter is ~65.5K.
+  max_tokens: 65536
   context_window: 200000  # GLM-4.7 supports 200K context
   pricing_currency: "$"
+  # OpenRouter official routing controls (pin to Z.AI route; no fallbacks)
+  request_overrides:
+    provider:
+      only: ["z-ai"]
+      allow_fallbacks: false
   models:
     glm-4.5-or:
       id: "z-ai/glm-4.5"

--- a/src/editor_assistant/config/llm_config.yml
+++ b/src/editor_assistant/config/llm_config.yml
@@ -151,11 +151,6 @@ zhipu-openrouter:
   max_tokens: 131100  # GLM-4.7 max output on OpenRouter
   context_window: 200000  # GLM-4.7 supports 200K context
   pricing_currency: "$"
-  # overides for the OpenRouter provider
-  request_overrides:
-    provider:
-      only: ["z-ai"]
-      allow_fallbacks: false
   models:
     glm-4.5-or:
       id: "z-ai/glm-4.5"

--- a/src/editor_assistant/config/llm_config.yml
+++ b/src/editor_assistant/config/llm_config.yml
@@ -71,7 +71,28 @@ gemini:
       pricing: { input: 0.5, output: 3.00 } 
     gemini-3-pro:
       id: "gemini-3-pro-preview"
-      pricing: { input: 2.00, output: 12.00 } # USD per 1M tokens 
+      pricing: { input: 2.00, output: 12.00 } # USD per 1M tokens
+
+# Gemini Free Tier - uses separate API key with stricter rate limits
+# Rate limits are conservative; update after testing with AI Studio data
+gemini-free:
+  api_key_env_var: "GEMINI_FT_API_KEY"
+  api_base_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+  temperature: 1.0
+  max_tokens: 65536
+  context_window: 1000000
+  pricing_currency: "$"
+  # Conservative rate limiting - update after testing
+  rate_limit:
+    min_interval_seconds: 12.0  # ~5 RPM, very conservative
+    max_requests_per_minute: 5
+  models:
+    gemini-3-flash-free:
+      id: "gemini-3-flash-preview"
+      pricing: { input: 0.0, output: 0.0 }
+    gemini-3-pro-free:
+      id: "gemini-3-pro-preview"
+      pricing: { input: 0.0, output: 0.0 } 
 
 kimi-volcengine:
   api_key_env_var: "KIMI_API_KEY_VOLC"
@@ -107,8 +128,8 @@ zhipu:
   api_key_env_var: "ZHIPU_API_KEY"
   api_base_url: "https://open.bigmodel.cn/api/paas/v4/chat/completions"
   temperature: 0.6
-  max_tokens: 96000
-  context_window: 128000
+  max_tokens: 128000  # GLM-4.7 supports up to 128K output
+  context_window: 200000  # GLM-4.7 supports 200K context
   pricing_currency: "$"
   models:
     glm-4.5:
@@ -117,13 +138,16 @@ zhipu:
     glm-4.6:
       id: "glm-4.6"
       pricing: {input: 0.60, output: 2.20}
+    glm-4.7:
+      id: "glm-4.7"
+      pricing: {input: 0.60, output: 2.20}
 
 zhipu-openrouter:
   api_key_env_var: "ZHIPU_API_KEY_OPENROUTER"
   api_base_url: *openrouter_endpoint
   temperature: 0.6
-  max_tokens: 96000
-  context_window: 131100
+  max_tokens: 131100  # GLM-4.7 max output on OpenRouter
+  context_window: 200000  # GLM-4.7 supports 200K context
   pricing_currency: "$"
   # overides for the OpenRouter provider
   request_overrides:
@@ -137,6 +161,9 @@ zhipu-openrouter:
     glm-4.6-or:
       id: "z-ai/glm-4.6"
       pricing: {input: 0.60, output: 2.00}
+    glm-4.7-or:
+      id: "z-ai/glm-4.7"
+      pricing: {input: 0.60, output: 2.20}
 
 doubao:
   api_key_env_var: "DOUBAO_API_KEY"

--- a/src/editor_assistant/config/llm_config.yml
+++ b/src/editor_assistant/config/llm_config.yml
@@ -74,24 +74,26 @@ gemini:
       pricing: { input: 2.00, output: 12.00 } # USD per 1M tokens
 
 # Gemini Free Tier - uses separate API key with stricter rate limits
-# Rate limits are conservative; update after testing with AI Studio data
+# Rate limits from AI Studio (2026-01-04):
+#   gemini-2.5-flash: 5 RPM, 250K TPM, 20 RPD
+#   gemini-2.5-flash-lite: 10 RPM, 250K TPM, 20 RPD
+# Note: Free tier does NOT support 3-pro
 gemini-free:
   api_key_env_var: "GEMINI_FT_API_KEY"
   api_base_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
   temperature: 1.0
   max_tokens: 65536
-  context_window: 1000000
+  context_window: 1000000  # 1M context
   pricing_currency: "$"
-  # Conservative rate limiting - update after testing
   rate_limit:
-    min_interval_seconds: 12.0  # ~5 RPM, very conservative
+    min_interval_seconds: 12.0  # 5 RPM
     max_requests_per_minute: 5
   models:
-    gemini-3-flash-free:
-      id: "gemini-3-flash-preview"
+    gemini-2.5-flash-free:
+      id: "gemini-2.5-flash"
       pricing: { input: 0.0, output: 0.0 }
-    gemini-3-pro-free:
-      id: "gemini-3-pro-preview"
+    gemini-2.5-flash-lite-free:
+      id: "gemini-2.5-flash-lite"
       pricing: { input: 0.0, output: 0.0 } 
 
 kimi-volcengine:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,12 +23,24 @@ from unittest.mock import Mock, MagicMock
 # PYTEST CONFIGURATION
 # ============================================================================
 
+def pytest_addoption(parser):
+    """Add custom pytest command-line options."""
+    parser.addoption(
+        "--integration-model",
+        action="store",
+        default="base",
+        choices=["base", "advanced"],
+        help="Model tier for integration tests: base (deepseek-v3.2) or advanced (gemini-3-flash-free)"
+    )
+
+
 def pytest_configure(config):
     """Register custom markers."""
     config.addinivalue_line("markers", "unit: Fast unit tests (mocked)")
     config.addinivalue_line("markers", "integration: Integration tests (real API)")
     config.addinivalue_line("markers", "slow: Slow running tests")
     config.addinivalue_line("markers", "expensive: Tests that cost money")
+    config.addinivalue_line("markers", "advanced: Tests requiring advanced models (gemini)")
 
 
 # ============================================================================
@@ -212,10 +224,18 @@ def mock_failing_llm_client():
 # REAL CLIENT FIXTURES (for integration tests)
 # ============================================================================
 
+# Model constants for integration tests
+INTEGRATION_MODELS = {
+    "base": "deepseek-v3.2",           # Cheap, fast - default for integration tests
+    "advanced": "gemini-3-flash-free"   # Free tier Gemini - for advanced model testing
+}
+
+
 @pytest.fixture
-def budget_model_name() -> str:
-    """Return the cheapest model for testing."""
-    return "deepseek-v3.2"
+def budget_model_name(request) -> str:
+    """Return the model for integration testing based on --integration-model option."""
+    tier = request.config.getoption("--integration-model")
+    return INTEGRATION_MODELS.get(tier, INTEGRATION_MODELS["base"])
 
 
 @pytest.fixture
@@ -223,6 +243,18 @@ def real_llm_client(budget_model_name):
     """Create a real LLM client for integration tests."""
     from editor_assistant.llm_client import LLMClient
     return LLMClient(budget_model_name)
+
+
+@pytest.fixture
+def advanced_model_name() -> str:
+    """Return the advanced model name (gemini-3-flash-free)."""
+    return INTEGRATION_MODELS["advanced"]
+
+
+@pytest.fixture
+def base_model_name() -> str:
+    """Return the base model name (deepseek-v3.2)."""
+    return INTEGRATION_MODELS["base"]
 
 
 # ============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def pytest_addoption(parser):
         action="store",
         default="base",
         choices=["base", "advanced"],
-        help="Model tier for integration tests: base (deepseek-v3.2) or advanced (gemini-3-flash-free)"
+        help="Model tier for integration tests: base (deepseek-v3.2) or advanced (gemini-2.5-flash-free)"
     )
 
 
@@ -226,8 +226,8 @@ def mock_failing_llm_client():
 
 # Model constants for integration tests
 INTEGRATION_MODELS = {
-    "base": "deepseek-v3.2",           # Cheap, fast - default for integration tests
-    "advanced": "gemini-3-flash-free"   # Free tier Gemini - for advanced model testing
+    "base": "deepseek-v3.2",              # Cheap, fast - default for integration tests
+    "advanced": "gemini-2.5-flash-free"   # Free tier Gemini 2.5 - for advanced model testing
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -247,7 +247,7 @@ def real_llm_client(budget_model_name):
 
 @pytest.fixture
 def advanced_model_name() -> str:
-    """Return the advanced model name (gemini-3-flash-free)."""
+    """Return the advanced model name (gemini-2.5-flash-free)."""
     return INTEGRATION_MODELS["advanced"]
 
 


### PR DESCRIPTION
## What
- Add Zhipu GLM-4.7 support (native + OpenRouter) and set OpenRouter GLM-4.7 as the default model.
- Add Gemini Free Tier provider using `GEMINI_FT_API_KEY` with `gemini-2.5-flash-free` and `gemini-2.5-flash-lite-free`.
- Add integration-test option `--integration-model` (base/advanced), defaulting to DeepSeek.

## Why
- Support Zhipu’s latest flagship model.
- Enable reliable, low-cost advanced integration testing via Gemini Free Tier.

## How
- `llm_config.yml`: add models/providers + rate limits; for OpenRouter routing keep official `provider` override and cap `max_tokens` to avoid OpenRouter 404 when provider is pinned.
- `tests/conftest.py`: add `--integration-model` selector.

## Testing
- Manual live API calls:
  - `gemini-2.5-flash-free` returns 200
  - `glm-4.7-or` returns 200 (with provider pinned)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces new model support and testing options, and updates defaults.
> 
> - **Models/config**: Add GLM-4.7 for Zhipu (native `glm-4.7`) and OpenRouter (`glm-4.7-or`); update `zhipu` context to 200K and `max_tokens` to 128K; cap `zhipu-openrouter` `max_tokens` at 65,536 and pin provider via `request_overrides`; add `gemini-free` provider with `gemini-2.5-flash-free` and `gemini-2.5-flash-lite-free` and rate limits in `llm_config.yml`.
> - **CLI default**: Switch `DEFAULT_MODEL` in `cli.py` from `deepseek-v3.2` to `glm-4.7-or`.
> - **Tests**: Add `pytest` option `--integration-model` (base/advanced) and related fixtures in `tests/conftest.py`.
> - **Docs/Meta**: Update `CHANGELOG.md`, `TODO.md`, and add RFC `docs/design_docs/rfc_glm47_gemini_free.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4db084bb2c51f65c2532097a13729d8358934adc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->