### PR TITLE
feat(models): refresh catalog for 2026 Q2 — closes #19

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -269,18 +269,44 @@ Structure:
 
 ```yaml
 provider-name:
-  api_key_env_var: "ENV_VAR_NAME"
-  api_base_url: "https://..."
+  api_key_env_var: "ENV_VAR_NAME"      # env var holding the API key
+  api_base_url: "https://..."           # OpenAI-compatible /chat/completions URL
   temperature: 0.6
-  max_tokens: 32000
-  context_window: 128000
-  pricing_currency: "$"
-  request_overrides: {}  # Optional: extra API params
+  max_tokens: 32000                     # default max output tokens (provider-wide)
+  context_window: 128000                # default context window (provider-wide)
+  pricing_currency: "$"                 # "$" or "¥"
+  rate_limit:                           # optional, provider-wide
+    min_interval_seconds: 1.0           # min seconds between requests (default 0.5)
+    max_requests_per_minute: 30         # 0 = unlimited (default 60)
+  request_overrides:                    # optional dict merged into every request payload
+    provider:                           # example: pin OpenRouter routing
+      only: ["z-ai"]
+      allow_fallbacks: false
   models:
     model-name:
       id: "actual-api-id"
-      pricing: {input: X, output: Y}
+      pricing: {input: X, output: Y}    # USD or CNY per 1M tokens
 ```
+
+Top-level keys starting with `_` (e.g. `_shared_endpoints`) are skipped by the loader and used for YAML anchor / alias deduplication. Schema is enforced by Pydantic in `config/llm_models.py` (`ProviderSettings`, `ModelDetails`).
+
+#### Supported Providers (current)
+
+| Provider key | Endpoint | Currency | Used for |
+| --- | --- | --- | --- |
+| `deepseek` | `api.deepseek.com` (official) | $ | DeepSeek V3.2, R1, V4-Flash, V4-Pro |
+| `deepseek-volcengine` | Volcengine Ark | ¥ | DeepSeek V3.2, R1 (proxied via Volcengine) |
+| `gemini` | Gemini API direct | $ | Gemini 3-flash, 3.1-flash-lite, 3.1-pro |
+| `gemini-free` | Gemini API direct (free key) | $ | 2.5/3-flash free tier |
+| `kimi-volcengine` | Volcengine Ark | ¥ | Kimi K2 |
+| `qwen` | Bailian (DashScope-compatible) | ¥ | Qwen Turbo / Plus / 3.5-plus / 3-max |
+| `zhipu` | `open.bigmodel.cn` (direct) | $ | GLM-4.5 / 4.6 / 4.7 / 5 / 5.1 |
+| `zhipu-openrouter` | OpenRouter (pinned to `z-ai`) | $ | GLM via OpenRouter |
+| `doubao` | Volcengine Ark | ¥ | Doubao Seed 1.6 family |
+| `openai-openrouter` | OpenRouter | $ | GPT-4o / 4.1 / 5.x via OpenRouter |
+| `anthropic-openrouter` | OpenRouter | $ | Claude Sonnet 4.x / Opus 4.6+ / Haiku 4.5 |
+
+Adding a new provider is a config-only change (see [§3](#adding-a-new-llm-model)). The Pydantic schema in `config/llm_models.py` is the source of truth — modify it only when adding a new structural field, and update this section accordingly.
 
 ---
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -297,7 +297,7 @@ Top-level keys starting with `_` (e.g. `_shared_endpoints`) are skipped by the l
 | `deepseek` | `api.deepseek.com` (official) | $ | DeepSeek V3.2, R1, V4-Flash, V4-Pro |
 | `deepseek-volcengine` | Volcengine Ark | ¥ | DeepSeek V3.2, R1 (proxied via Volcengine) |
 | `gemini` | Gemini API direct | $ | Gemini 3-flash, 3.1-flash-lite, 3.1-pro |
-| `gemini-free` | Gemini API direct (free key) | $ | Free tier: 2.5-flash, 2.5-flash-lite, 3-flash-preview |
+| `gemini-free` | Gemini API direct (free key) | $ | Free tier: 2.5-flash, 2.5-flash-lite, 3-flash-preview, 3.1-flash-lite-preview |
 | `kimi-volcengine` | Volcengine Ark | ¥ | Kimi K2 |
 | `qwen` | Bailian (DashScope-compatible) | ¥ | Qwen Turbo / Plus / 3.5-plus / 3-max |
 | `zhipu` | `open.bigmodel.cn` (direct) | $ | GLM-4.5 / 4.6 / 4.7 / 5 / 5.1 |

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -297,7 +297,7 @@ Top-level keys starting with `_` (e.g. `_shared_endpoints`) are skipped by the l
 | `deepseek` | `api.deepseek.com` (official) | $ | DeepSeek V3.2, R1, V4-Flash, V4-Pro |
 | `deepseek-volcengine` | Volcengine Ark | ¥ | DeepSeek V3.2, R1 (proxied via Volcengine) |
 | `gemini` | Gemini API direct | $ | Gemini 3-flash, 3.1-flash-lite, 3.1-pro |
-| `gemini-free` | Gemini API direct (free key) | $ | 2.5/3-flash free tier |
+| `gemini-free` | Gemini API direct (free key) | $ | Free tier: 2.5-flash, 2.5-flash-lite, 3-flash-preview |
 | `kimi-volcengine` | Volcengine Ark | ¥ | Kimi K2 |
 | `qwen` | Bailian (DashScope-compatible) | ¥ | Qwen Turbo / Plus / 3.5-plus / 3-max |
 | `zhipu` | `open.bigmodel.cn` (direct) | $ | GLM-4.5 / 4.6 / 4.7 / 5 / 5.1 |

--- a/src/editor_assistant/config/llm_config.yml
+++ b/src/editor_assistant/config/llm_config.yml
@@ -35,22 +35,36 @@ deepseek-volcengine:
   models:
     deepseek-v3.2:
       id: "deepseek-v3-2-251201"
-      pricing: { input: 4.00, output: 6.00 }
+      pricing: { input: 2.00, output: 8.00 }
     deepseek-r1:
       id: "deepseek-r1-250528"
-      pricing: { input: 4.00, output: 12.00 }
+      pricing: { input: 4.00, output: 16.00 }
 
-# deepseek:
-#   api_key_env_var: "DEEPSEEK_API_KEY"
-#   api_base_url: "https://api.deepseek.com/chat/completions"
-#   temperature: 0.4
-#   max_tokens: 32000
-#   context_window: 128000
-#   pricing_currency: "$"
-#   models:
-#     deepseek-v3.2:
-#       id: "deepseek-reasoner"
-#       pricing: { input: 0.28, output: 0.42}
+# DeepSeek official API. V4 and V4-Pro are exclusive to this endpoint (not on Volcengine).
+# Block defaults match V3.2 / R1 limits; V4 family is capped here pending #21
+# (per-model max_tokens / context_window override).
+deepseek:
+  api_key_env_var: "DEEPSEEK_API_KEY"
+  api_base_url: "https://api.deepseek.com/chat/completions"
+  temperature: 0.4
+  max_tokens: 64000  # V3.2/R1 max output; V4-Flash/V4-Pro support 384K (capped here)
+  context_window: 128000  # V3.2/R1 context; V4-Flash/V4-Pro support 1M (capped here)
+  pricing_currency: "$"
+  models:
+    deepseek-v3.2-official:
+      id: "deepseek-v3.2"
+      pricing: { input: 0.28, output: 0.42 }
+    deepseek-r1-official:
+      id: "deepseek-r1"
+      pricing: { input: 0.55, output: 2.19 }
+    deepseek-v4-flash:
+      id: "deepseek-v4-flash"
+      pricing: { input: 0.14, output: 0.28 }
+    # V4-Pro is on a 75% promo through 2026-05-31; standard rates resume after.
+    # Standard: input $1.74 / output $3.48
+    deepseek-v4-pro:
+      id: "deepseek-v4-pro"
+      pricing: { input: 0.435, output: 0.87 }
 
 gemini:
   api_key_env_var: "GEMINI_API_KEY"
@@ -68,19 +82,22 @@ gemini:
   models:
     gemini-3-flash:
       id: "gemini-3-flash-preview"
-      pricing: { input: 0.5, output: 3.00 } 
-    gemini-3-pro:
-      id: "gemini-3-pro-preview"
-      pricing: { input: 2.00, output: 12.00 } # USD per 1M tokens
+      pricing: { input: 0.5, output: 3.00 }
+    gemini-3.1-flash-lite:
+      id: "gemini-3.1-flash-lite-preview"
+      pricing: { input: 0.25, output: 1.50 }
     gemini-3.1-pro:
       id: "gemini-3.1-pro-preview"
       pricing: { input: 2.50, output: 15.00 }
 
-# Gemini Free Tier - uses separate API key with stricter rate limits
-# Rate limits from AI Studio (2026-01-04):
-#   gemini-2.5-flash: 5 RPM, 250K TPM, 20 RPD
-#   gemini-2.5-flash-lite: 10 RPM, 250K TPM, 20 RPD
-# Note: Free tier does NOT support 3-pro
+# Gemini Free Tier - uses separate API key with stricter rate limits.
+# Provider-wide rate_limit applies to ALL models in this block; we use the most
+# restrictive cap to avoid throttling violations on any one model.
+# Per-model limits (per ai.google.dev/gemini-api/docs/rate-limits, 2026-Q2):
+#   gemini-2.5-flash:        ~10 RPM, 250K TPM, ~250 RPD
+#   gemini-2.5-flash-lite:   ~15 RPM, 250K TPM, ~1K RPD
+#   gemini-3-flash-preview:  TBD (lower than 2.5-flash; verify in AI Studio)
+# Note: Free tier does NOT support 3-pro / 3.1-pro.
 gemini-free:
   api_key_env_var: "GEMINI_FT_API_KEY"
   api_base_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
@@ -89,7 +106,7 @@ gemini-free:
   context_window: 1000000  # 1M context
   pricing_currency: "$"
   rate_limit:
-    min_interval_seconds: 12.0  # 5 RPM
+    min_interval_seconds: 12.0  # conservative: respects 3-flash-preview unknown cap
     max_requests_per_minute: 5
   models:
     gemini-2.5-flash-free:
@@ -97,7 +114,10 @@ gemini-free:
       pricing: { input: 0.0, output: 0.0 }
     gemini-2.5-flash-lite-free:
       id: "gemini-2.5-flash-lite"
-      pricing: { input: 0.0, output: 0.0 } 
+      pricing: { input: 0.0, output: 0.0 }
+    gemini-3-flash-free:
+      id: "gemini-3-flash-preview"
+      pricing: { input: 0.0, output: 0.0 }
 
 kimi-volcengine:
   api_key_env_var: "KIMI_API_KEY_VOLC"
@@ -111,6 +131,8 @@ kimi-volcengine:
       id: "kimi-k2-250905"
       pricing: {input: 4.00, output: 16.00}
 
+# Alibaba Bailian (百炼) — same OpenAI-compatible endpoint as legacy DashScope.
+# Tiered pricing for qwen3-max above 32K input is tracked in #6.
 qwen:
   api_key_env_var: "QWEN_API_KEY"
   api_base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
@@ -119,15 +141,21 @@ qwen:
   context_window: 995904
   pricing_currency: "¥"
   models:
+    qwen-turbo:
+      id: "qwen-turbo"
+      pricing: {input: 0.30, output: 0.60}
     qwen-plus:
       id: "qwen-plus"
-      pricing: {input: 0.80, output: 2.00} # with thinking model defaultly disabled
+      pricing: {input: 0.80, output: 2.00}  # thinking mode disabled by default
+    qwen3.5-plus:
+      id: "qwen3.5-plus"
+      pricing: {input: 0.80, output: 4.80}
     qwen3-max-preview:
       id: "qwen3-max-preview"
-      pricing: {input: 0.60, output: 24.00} 
+      pricing: {input: 2.50, output: 10.00}  # ≤32K input tier
     qwen3-max:
       id: "qwen3-max"
-      pricing: {input: 0.60, output: 24.00} 
+      pricing: {input: 2.50, output: 10.00}  # ≤32K input tier
 
 zhipu:
   api_key_env_var: "ZHIPU_API_KEY"
@@ -146,6 +174,12 @@ zhipu:
     glm-4.7:
       id: "glm-4.7"
       pricing: {input: 0.60, output: 2.20}
+    glm-5:
+      id: "glm-5"
+      pricing: {input: 0.60, output: 1.92}
+    glm-5.1:
+      id: "glm-5.1"
+      pricing: {input: 1.05, output: 3.50}
 
 zhipu-openrouter:
   api_key_env_var: "ZHIPU_API_KEY_OPENROUTER"
@@ -155,7 +189,7 @@ zhipu-openrouter:
   # will return 404 ("No allowed providers...") if max_tokens exceeds the pinned
   # provider's max output. GLM-4.7 max output shown on OpenRouter is ~65.5K.
   max_tokens: 65536
-  context_window: 200000  # GLM-4.7 supports 200K context
+  context_window: 202752  # OpenRouter z-ai routes report 202752, not 200000
   pricing_currency: "$"
   # OpenRouter official routing controls (pin to Z.AI route; no fallbacks)
   request_overrides:
@@ -168,10 +202,19 @@ zhipu-openrouter:
       pricing: {input: 0.38, output: 1.60}
     glm-4.6-or:
       id: "z-ai/glm-4.6"
-      pricing: {input: 0.60, output: 2.00}
+      pricing: {input: 0.39, output: 1.90}
     glm-4.7-or:
       id: "z-ai/glm-4.7"
-      pricing: {input: 0.60, output: 2.20}
+      pricing: {input: 0.40, output: 1.75}
+    glm-5-or:
+      id: "z-ai/glm-5"
+      pricing: {input: 0.60, output: 1.92}
+    glm-5.1-or:
+      id: "z-ai/glm-5.1"
+      pricing: {input: 1.05, output: 3.50}
+    glm-5-turbo-or:
+      id: "z-ai/glm-5-turbo"
+      pricing: {input: 1.20, output: 4.00}
 
 doubao:
   api_key_env_var: "DOUBAO_API_KEY"
@@ -184,6 +227,9 @@ doubao:
     doubao-seed-1.6:
       id: "doubao-seed-1-6-250615"
       pricing: {input: 0.80, output: 2.00}
+    doubao-seed-1.6-lite:
+      id: "doubao-seed-1-6-lite-250615"
+      pricing: {input: 0.30, output: 2.40}
 
 openai-openrouter:
   api_key_env_var: "OPENAI_API_KEY_OPENROUTER"
@@ -205,6 +251,12 @@ openai-openrouter:
     gpt-5.2-or:
       id: "openai/gpt-5.2"
       pricing: {input: 1.75, output: 14.00}
+    gpt-5.4-or:
+      id: "openai/gpt-5.4"
+      pricing: {input: 2.50, output: 15.00}
+    gpt-5.5-or:
+      id: "openai/gpt-5.5"
+      pricing: {input: 5.00, output: 30.00}
 
 anthropic-openrouter:
   api_key_env_var: "ANTHROPIC_API_KEY_OPENROUTER"
@@ -227,3 +279,9 @@ anthropic-openrouter:
     claude-sonnet-4.6-or:
       id: "anthropic/claude-sonnet-4.6"
       pricing: {input: 3.00, output: 15.00}
+    claude-opus-4.7-or:
+      id: "anthropic/claude-opus-4.7"
+      pricing: {input: 5.00, output: 25.00}
+    claude-haiku-4.5-or:
+      id: "anthropic/claude-haiku-4.5"
+      pricing: {input: 1.00, output: 5.00}

--- a/src/editor_assistant/config/llm_config.yml
+++ b/src/editor_assistant/config/llm_config.yml
@@ -92,12 +92,15 @@ gemini:
 
 # Gemini Free Tier - uses separate API key with stricter rate limits.
 # Provider-wide rate_limit applies to ALL models in this block; we use the most
-# restrictive cap to avoid throttling violations on any one model.
-# Per-model limits (per ai.google.dev/gemini-api/docs/rate-limits, 2026-Q2):
-#   gemini-2.5-flash:        ~10 RPM, 250K TPM, ~250 RPD
-#   gemini-2.5-flash-lite:   ~15 RPM, 250K TPM, ~1K RPD
-#   gemini-3-flash-preview:  TBD (lower than 2.5-flash; verify in AI Studio)
-# Note: Free tier does NOT support 3-pro / 3.1-pro.
+# restrictive cap (10 RPM) to avoid throttling violations on any free-tier model.
+# Verified per ai.google.dev/gemini-api/docs/pricing (May 2026 — free tier was
+# tightened 2026-04-01: Pro models moved to paid; Flash retained at reduced RPD):
+#   gemini-2.5-flash:               10 RPM, 250K TPM
+#   gemini-2.5-flash-lite:          15 RPM, 250K TPM
+#   gemini-3-flash-preview:         10 RPM (lowest published flash cap)
+#   gemini-3.1-flash-lite-preview:  free, RPM unpublished — fall back to 10
+# Note: Free tier does NOT support gemini-3-pro / gemini-3.1-pro (paid only).
+# Exact per-project RPD/TPM is shown in AI Studio dashboard, not this comment.
 gemini-free:
   api_key_env_var: "GEMINI_FT_API_KEY"
   api_base_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
@@ -106,8 +109,8 @@ gemini-free:
   context_window: 1000000  # 1M context
   pricing_currency: "$"
   rate_limit:
-    min_interval_seconds: 12.0  # conservative: respects 3-flash-preview unknown cap
-    max_requests_per_minute: 5
+    min_interval_seconds: 6.0  # 10 RPM = 60s / 10
+    max_requests_per_minute: 10
   models:
     gemini-2.5-flash-free:
       id: "gemini-2.5-flash"

--- a/src/editor_assistant/config/llm_config.yml
+++ b/src/editor_assistant/config/llm_config.yml
@@ -43,6 +43,10 @@ deepseek-volcengine:
 # DeepSeek official API. V4 and V4-Pro are exclusive to this endpoint (not on Volcengine).
 # Block defaults match V3.2 / R1 limits; V4 family is capped here pending #21
 # (per-model max_tokens / context_window override).
+# Model IDs sourced from api-docs.deepseek.com/quick_start/pricing (May 2026).
+# Recommend a live curl test before first production use — research was based on
+# search snippets, not direct page render. Aliases `deepseek-chat` and
+# `deepseek-reasoner` retire 2026-07-24.
 deepseek:
   api_key_env_var: "DEEPSEEK_API_KEY"
   api_base_url: "https://api.deepseek.com/chat/completions"
@@ -120,6 +124,9 @@ gemini-free:
       pricing: { input: 0.0, output: 0.0 }
     gemini-3-flash-free:
       id: "gemini-3-flash-preview"
+      pricing: { input: 0.0, output: 0.0 }
+    gemini-3.1-flash-lite-free:
+      id: "gemini-3.1-flash-lite-preview"
       pricing: { input: 0.0, output: 0.0 }
 
 kimi-volcengine:
@@ -230,6 +237,8 @@ doubao:
     doubao-seed-1.6:
       id: "doubao-seed-1-6-250615"
       pricing: {input: 0.80, output: 2.00}
+    # Volcengine output price for lite (¥2.40) appears higher than base (¥2.00).
+    # Reason TBD — base output may be ¥8 per Volcengine docs (tracked in #20).
     doubao-seed-1.6-lite:
       id: "doubao-seed-1-6-lite-250615"
       pricing: {input: 0.30, output: 2.40}


### PR DESCRIPTION
## Summary

Refreshes `llm_config.yml` for 2026 Q2: adds latest model generations across all providers, fixes verifiably-wrong prices on existing entries, and removes a discontinued Gemini model. Closes #19.

11 providers (was 10), **42 models** (was 25). 148 unit tests pass.

## Bug fixes (catalog had wrong values — would compute wrong cost)

| Entry | Before | After | Source |
|---|---|---|---|
| `deepseek-v3.2` (Volcengine) | ¥4 / ¥6 | ¥2 / ¥8 | [Volcengine model list](https://www.volcengine.com/docs/82379/1330310) |
| `deepseek-r1` (Volcengine) | ¥4 / ¥12 | ¥4 / ¥16 | [Volcengine R1 doc](https://www.volcengine.com/docs/82379/1554373) |
| `qwen3-max` / `qwen3-max-preview` | ¥0.60 / ¥24 | ¥2.50 / ¥10 (≤32K tier) | [Bailian pricing](https://help.aliyun.com/zh/model-studio/model-pricing) |
| `glm-4.6-or` | $0.60 / $2.00 | $0.39 / $1.90 | [OpenRouter z-ai/glm-4.6](https://openrouter.ai/z-ai/glm-4.6) |
| `glm-4.7-or` | $0.60 / $2.20 | $0.40 / $1.75 | [OpenRouter z-ai/glm-4.7](https://openrouter.ai/z-ai/glm-4.7) |
| `zhipu-openrouter` context | 200000 | 202752 | OpenRouter spec |

## Removed (model discontinued)

- `gemini-3-pro` — Google shut down `gemini-3-pro-preview` on 2026-03-26; calls would fail.

## Added — existing provider blocks

| Provider | New models | Pricing $ or ¥ per 1M tokens |
|---|---|---|
| `anthropic-openrouter` | `claude-opus-4.7-or`, `claude-haiku-4.5-or` | $5/$25, $1/$5 |
| `openai-openrouter` | `gpt-5.4-or`, `gpt-5.5-or` | $2.50/$15, $5/$30 |
| `gemini` | `gemini-3.1-flash-lite` | $0.25/$1.50 |
| `gemini-free` | `gemini-3-flash-free` | $0/$0 |
| `zhipu` (direct) | `glm-5`, `glm-5.1` | $0.60/$1.92, $1.05/$3.50 |
| `zhipu-openrouter` | `glm-5-or`, `glm-5.1-or`, `glm-5-turbo-or` | same + $1.20/$4.00 |
| `qwen` | `qwen-turbo`, `qwen3.5-plus` | ¥0.30/¥0.60, ¥0.80/¥4.80 |
| `doubao` | `doubao-seed-1.6-lite` | ¥0.30/¥2.40 |

## New provider block — `deepseek` (official API)

V4 family is exclusive to DeepSeek's own endpoint (not on Volcengine), so the previously-commented official block is now enabled and populated:

| Short name | API ID | Input $/M | Output $/M |
|---|---|---|---|
| `deepseek-v3.2-official` | `deepseek-v3.2` | $0.28 | $0.42 |
| `deepseek-r1-official` | `deepseek-r1` | $0.55 | $2.19 |
| `deepseek-v4-flash` | `deepseek-v4-flash` | $0.14 | $0.28 |
| `deepseek-v4-pro` | `deepseek-v4-pro` | **$0.435** ($1.74 after promo) | **$0.87** ($3.48 after promo) |

⚠️ V4-Pro is on a 75% promo through **2026-05-31**. Standard rates resume after — flagged in #20 for follow-up.

⚠️ Schema cap: V4 supports 1M context / 384K output but the provider block is set to 128K / 64K (V3.2/R1 limits). Tracked in #21.

## Out of scope (filed as follow-ups)

- **#20** — Volcengine + Bailian models awaiting console verification (Doubao Seed 1.8/2.0, Kimi K2.5/K2.6, Qwen 3.6 series — public docs are JS-rendered and not crawlable)
- **#21** — schema extension for per-model `max_tokens` / `context_window` override (so Claude Opus 4.7 / GPT-5.x / DeepSeek V4 can use their full capability)
- **#6** — tiered pricing (Gemini 3.x Pro >200K, qwen3-max >32K, Volcengine off-peak, DeepSeek cache-hit)

## Confidence note

Volcengine, Bailian, and DeepSeek pricing pages are JS-rendered. Research agents pulled values from search snippets pointing to official docs URLs (cited in commit message and table above). **Recommend a final spot-check** against the canonical pages before merge — especially the new `deepseek-v4-pro` promo rate.

## Test plan

- [x] `uv run pytest tests/unit/` — 148 passed
- [x] `uv run python -c "from editor_assistant.config.llm_models import load_all_settings; print(len(load_all_settings()))"` — loads 11 providers
- [x] `make models-list` — prints all 42 models
- [x] `editor-assistant --help` and library imports unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)