### PR TITLE
feat: refresh Qwen non-thinking catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Documented downstream package contract for LinkResearcher and other workers.
+- Added the dated Qwen/Bailian catalog decision record for Issue #31.
 
 ### Changed
-- Editor Assistant now packages and owns the exact `llm-exec-core` 0.3.0 21-model catalog while continuing to use core for schema validation and execution. Library callers may provide an explicit path or dictionary `config_source` without sharing the app default.
+- Editor Assistant continues to package and own its 21-model catalog while using `llm-exec-core` 0.4.1 for schema validation, generic connection resolution, effective model policy, and execution. Library callers may provide an explicit path or dictionary `config_source` without sharing the app default.
 - Changed the CLI/library migration default from `glm-4.7-or` to `glm-5.2-or`. Removed names such as `glm-4.7-or` and `glm-4.6-or` are not restored or mapped.
-- Constrained the runtime dependency to `llm-exec-core>=0.3.0,<0.4.0` while retaining the sibling editable source for development.
+- Constrained the runtime dependency to `llm-exec-core>=0.4.1,<0.5.0` while retaining the sibling editable source for development.
+- Refreshed only `qwen3.6-flash`: non-thinking requests are explicit, connection key/endpoint fallbacks are configurable, context/output limits are 1M/64K, and supported JSON/tool capabilities are recorded without adding Qwen models.
+- Retained Qwen's historical `¥0.30`/`¥0.60` flat prices only as non-authoritative compatibility placeholders pending tiered-pricing schema work in related-only `llm-exec-core` #23.
 
 ## [0.6.0] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This branch is a coordinated two-repo/local-migration branch. Keep the current s
 llm-exec-core = { path = "../llm-exec-core", editable = true }
 ```
 
-That relative source remains intentional for local development and workspace checkouts that test both repos together. Published installs use the declared `llm-exec-core>=0.3.0,<0.4.0` compatibility range; the editable source does not change that package boundary.
+That relative source remains intentional for local development and workspace checkouts that test both repos together. Published installs use the declared `llm-exec-core>=0.4.1,<0.5.0` compatibility range; the editable source does not change that package boundary.
 
 ### Features
 
@@ -76,6 +76,12 @@ export GEMINI_API_KEY=your_gemini_api_key
 
 # Qwen via Alibaba Bailian / DashScope-compatible endpoint
 export QWEN_API_KEY=your_qwen_api_key
+
+# If QWEN_API_KEY is unset, the official DashScope variable is the fallback
+export DASHSCOPE_API_KEY=your_qwen_api_key
+
+# Optional Qwen endpoint override: SDK base or full chat/completions URL
+export QWEN_API_BASE_URL=https://your-workspace.example/compatible-mode/v1
 
 # GLM via Zhipu AI
 export ZHIPU_API_KEY=your_zhipu_api_key
@@ -226,6 +232,12 @@ client = LLMClient(models[0], config_source=Path("custom_llm_config.yml"))
 
 - `qwen3.6-flash`
 
+`qwen3.6-flash` uses a 1,000,000-token context window and a 65,536-token maximum output. Editor Assistant explicitly sends `enable_thinking: false`; it does not translate `thinking_level` to Qwen `reasoning_effort`. `max_tokens` remains the selected Chat API field for this minimal refresh, although Alibaba marks it for future deprecation in favor of `max_completion_tokens`.
+
+`QWEN_API_KEY` has precedence over `DASHSCOPE_API_KEY`. If `QWEN_API_BASE_URL` is unset, the existing complete Beijing-compatible endpoint remains the fallback. An override may be either an SDK-style base ending in `/v1` or a complete `/chat/completions` endpoint.
+
+The catalog's `¥0.30` input and `¥0.60` output values are historical, non-authoritative compatibility placeholders. Current Qwen3.6 Flash billing varies by region, token tier, cache, Batch eligibility, deployment, and mode; do not use these flat values as a billing quote. Tiered pricing support remains related-only work in [llm-exec-core #23](https://github.com/lanmogu98/llm-exec-core/issues/23).
+
 #### GLM / Zhipu
 
 - Zhipu API (`ZHIPU_API_KEY`): `glm-5.2`, `glm-5`, `glm-5.1`
@@ -350,7 +362,7 @@ Editor Assistant 使用 `llm-exec-core` 提供模型目录 schema 与加载、pr
 llm-exec-core = { path = "../llm-exec-core", editable = true }
 ```
 
-这个相对路径仍用于本地开发和双仓 workspace checkout。发布安装遵循声明的 `llm-exec-core>=0.3.0,<0.4.0` 兼容范围；editable source 不会改变该包边界。
+这个相对路径仍用于本地开发和双仓 workspace checkout。发布安装遵循声明的 `llm-exec-core>=0.4.1,<0.5.0` 兼容范围；editable source 不会改变该包边界。
 
 ### 功能特色
 
@@ -407,6 +419,12 @@ export GEMINI_API_KEY=your_gemini_api_key
 
 # Qwen via Alibaba Bailian / DashScope-compatible endpoint
 export QWEN_API_KEY=your_qwen_api_key
+
+# QWEN_API_KEY 未设置时，回退到 DashScope 官方变量
+export DASHSCOPE_API_KEY=your_qwen_api_key
+
+# 可选的 Qwen endpoint 覆盖：SDK base 或完整 chat/completions URL
+export QWEN_API_BASE_URL=https://your-workspace.example/compatible-mode/v1
 
 # GLM via Zhipu AI
 export ZHIPU_API_KEY=your_zhipu_api_key
@@ -555,6 +573,12 @@ client = LLMClient(models[0], config_source=Path("custom_llm_config.yml"))
 #### Qwen
 
 - `qwen3.6-flash`
+
+`qwen3.6-flash` 使用 1,000,000 token 上下文窗口，最大输出为 65,536 token。Editor Assistant 会显式发送 `enable_thinking: false`，不会把 `thinking_level` 映射为 Qwen 的 `reasoning_effort`。本次最小刷新继续使用 Chat API 的 `max_tokens` 字段；阿里云已提示未来应迁移到 `max_completion_tokens`。
+
+`QWEN_API_KEY` 的优先级高于 `DASHSCOPE_API_KEY`。未设置 `QWEN_API_BASE_URL` 时，继续使用现有的北京兼容完整 endpoint；覆盖值可以是以 `/v1` 结尾的 SDK base，也可以是完整的 `/chat/completions` endpoint。
+
+目录中的输入 `¥0.30`、输出 `¥0.60` 是历史兼容占位值，并非权威价格。当前 Qwen3.6 Flash 计费会随地域、token 阶梯、缓存、Batch 资格、部署方式和模式变化，请勿把这组平面值当作计费报价。阶梯定价 schema 仍由相关但不阻塞本 Issue 的 [llm-exec-core #23](https://github.com/lanmogu98/llm-exec-core/issues/23) 跟踪。
 
 #### GLM / 智谱
 

--- a/docs/design_docs/issue_31_qwen_catalog_decision.md
+++ b/docs/design_docs/issue_31_qwen_catalog_decision.md
@@ -1,0 +1,111 @@
+# Issue #31 Qwen/Bailian Catalog Decision
+
+## Status and scope
+
+This record implements the maintainer-approved minimal, non-thinking refresh on
+2026-07-22. Editor Assistant adds no Qwen models and retains only the existing
+logical key `qwen3.6-flash`. Public documentation mentioning a model is evidence
+to consider, not authorization to add it.
+
+Editor Assistant issue
+[20](https://github.com/lanmogu98/editor-assistant/issues/20) and
+`llm-exec-core` issue
+[23](https://github.com/lanmogu98/llm-exec-core/issues/23) are related-only.
+Neither is a prerequisite, blocker, parent, or child of Issue #31.
+
+## Release provenance
+
+| Evidence | Verified value |
+|---|---|
+| Core release | https://github.com/lanmogu98/llm-exec-core/releases/tag/0.4.1 |
+| Annotated tag | `refs/tags/0.4.1` -> tag `8e8e0a0813dccd068158cbe05bc22d3298f935f9` -> commit `3014b4b09f2f40db9820fac1f39e6f7c308fb654` |
+| Wheel | https://github.com/lanmogu98/llm-exec-core/releases/download/0.4.1/llm_exec_core-0.4.1-py3-none-any.whl — 24,243 bytes; SHA-256 `30dbc41afa29cf1e74d572703a93111f65ab7581eae4d69d739fe292d007e6f7` |
+| Source distribution | https://github.com/lanmogu98/llm-exec-core/releases/download/0.4.1/llm_exec_core-0.4.1.tar.gz — 26,059 bytes; SHA-256 `4a9f253fc7dae692358e958a7c5bf032d741d4f3afb135a147aa0f229df37662` |
+| Installed artifacts | Wheel and sdist independently install offline as `llm-exec-core==0.4.1` on Python 3.13 and declare `Requires-Python >=3.10`. |
+| Released core catalog | Public source, wheel, sdist, and isolated installations contain byte-identical `llm_config.yml`, SHA-256 `490c5df6988c43b65badf28f75a8507e09c11505a2d4f47ecb2bda42984abfd4`. |
+| Refreshed editor catalog | Editor Assistant owns its complete 21-model catalog; the post-refresh `llm_config.yml` SHA-256 is `65b97a4b5c9fa6f25b58b99e3f7919c5a14e7fb1a858f1a18fa92b7c56c421b7`. |
+
+The annotated tag and GitHub Release assets are the publication provenance; no
+PyPI publication is assumed. Local development intentionally keeps the sibling
+editable source while the built editor distribution declares
+`llm-exec-core>=0.4.1,<0.5.0`.
+
+## Accepted runtime policy
+
+| Dimension | Decision |
+|---|---|
+| Logical/outbound model | `qwen3.6-flash` -> `qwen3.6-flash` |
+| Model set | Exactly one Qwen key; no add, remove, alias, or remap |
+| Context/output | `1000000` context; `65536` maximum output |
+| Token field | `max_tokens`; accepted by the current Chat API but marked for future deprecation in favor of `max_completion_tokens` |
+| Thinking | Always send `enable_thinking: false`; no `reasoning_effort` mapping; `reasoning_controls: []` |
+| Credentials | `QWEN_API_KEY` first, then `DASHSCOPE_API_KEY` |
+| Endpoint | `QWEN_API_BASE_URL` accepts an SDK `/v1` base or complete `/chat/completions`; the legacy complete Beijing endpoint remains the fallback |
+| Structured output | JSON object supported; strict JSON-schema enforcement not claimed |
+| Tools | Tools, streaming tool output, tool choice, and parallel tool calls supported in the selected non-thinking mode |
+
+## Post-publication evidence and candidate decisions
+
+All sources were re-fetched on 2026-07-22 (Asia/Shanghai). No page
+representation hash or authenticated console evidence is used.
+
+| Candidate | Official source | Date | Supported fact | Disposition | Compatibility note and evidence limitation |
+|---|---|---|---|---|---|
+| `qwen3.6-flash` | https://help.aliyun.com/en/model-studio/text-generation-model/ and https://help.aliyun.com/en/model-studio/vision-model/ | 2026-07-22 | Current lightweight alias; maps to `qwen3.6-flash-2026-04-16`; 1M context and 64K maximum output; not listed for retirement | **Retain with limitation** | Keep the stable logical ID and force non-thinking. Flat pricing is not authoritative. |
+| `qwen3.6-flash-2026-04-16` | https://help.aliyun.com/en/model-studio/text-generation-model/ | 2026-07-22 | Dated snapshot behind the retained alias | **Omit** | Adding a snapshot would expand the public catalog without an accepted compatibility need. |
+| Qwen3.8 aliases, previews, and dated variants (`qwen3.8-*`) | https://help.aliyun.com/en/model-studio/text-generation-model/ | 2026-07-22 | Refreshed sources surface newer Qwen candidates | **Omit** | Newness does not override the accepted one-model scope; complete flat pricing is not representable. |
+| Qwen3.7 Max/Plus aliases, previews, and dated variants (`qwen3.7-*`) | https://help.aliyun.com/en/model-studio/text-generation-model/ and https://help.aliyun.com/zh/model-studio/model-pricing | 2026-07-22 | Official current/dated candidates with differing thinking and pricing characteristics | **Omit** | Promotions, modes, snapshots, and pricing dimensions cannot be represented as one universal flat rate. |
+| Qwen3.6 Plus/Max aliases and snapshots (`qwen3.6-plus*`, `qwen3.6-max*`) | https://help.aliyun.com/en/model-studio/text-generation-model/ and https://help.aliyun.com/zh/model-studio/model-pricing | 2026-07-22 | Official family candidates | **Omit** | Not current app keys; adding them would broaden scope and their pricing is dimensioned. |
+| Qwen3.5 candidates (`qwen3.5-*`) | https://help.aliyun.com/en/model-studio/text-generation-model/ and https://help.aliyun.com/en/model-studio/vision-model/ | 2026-07-22 | Legacy aliases and snapshots remain documented | **Omit** | Documentation presence alone is not an add decision; tiered pricing remains unrepresentable. |
+| `qwen3-max`, previews, `latest`, and dated variants | https://help.aliyun.com/en/model-studio/text-generation-model/ and https://www.alibabacloud.com/help/en/model-studio/model-depreciation | 2026-07-22 | Legacy family with lifecycle constraints | **Omit** | Do not reintroduce absent legacy keys or encode lifecycle-sensitive aliases. |
+| `qwen-max`, `latest`, and dated variants | https://help.aliyun.com/en/model-studio/text-generation-model/ | 2026-07-22 | Legacy family; thinking behavior differs from retained Qwen3.6 policy | **Omit** | No current app key and no verified need to restore one. |
+| `qwen-plus`, `latest`, and dated variants | https://help.aliyun.com/en/model-studio/text-generation-model/ and https://help.aliyun.com/zh/model-studio/model-pricing | 2026-07-22 | Legacy family with tier- and mode-dependent pricing | **Omit** | No alias remap is inferred; flat schema cannot represent current billing. |
+| `qwen-turbo`, `latest`, and dated variants | https://help.aliyun.com/en/model-studio/text-generation-model/ and https://help.aliyun.com/en/model-studio/deep-thinking | 2026-07-22 | Legacy family with mode-dependent behavior and pricing | **Omit** | No evidence requires `qwen-turbo` -> `qwen-turbo-latest`; do not restore or remap it. |
+
+Capability-specific sources:
+
+- Non-thinking and explicit `enable_thinking: false`:
+  https://help.aliyun.com/en/model-studio/deep-thinking
+- JSON-object output without strict schema:
+  https://help.aliyun.com/en/model-studio/qwen-structured-output
+- Function Calling, tool choice, parallel calls, and streaming tool output:
+  https://help.aliyun.com/en/model-studio/qwen-function-calling
+- OpenAI-compatible Chat fields, including the `max_tokens` lifecycle note:
+  https://help.aliyun.com/en/model-studio/qwen-api-via-openai-chat-completions
+- Key and endpoint compatibility:
+  https://help.aliyun.com/zh/model-studio/compatibility-of-openai-with-dashscope
+- Batch scope and limitations:
+  https://help.aliyun.com/en/model-studio/batch-inference
+- English pricing cross-check:
+  https://www.alibabacloud.com/help/en/model-studio/model-pricing
+- General text-generation behavior:
+  https://help.aliyun.com/en/model-studio/text-generation
+
+## Pricing limitation
+
+The retained `¥0.30` input and `¥0.60` output values are historical,
+non-authoritative compatibility placeholders. They are not current Qwen3.6
+Flash rates and must not be used as a billing quote. Official billing varies by
+region/deployment, input-token tier, cache behavior, Batch eligibility, and
+thinking mode. The shared flat `input`/`output` schema cannot encode those
+dimensions. No currency conversion or single tier is promoted to a universal
+rate; schema work remains related-only `llm-exec-core` issue 23.
+
+## Compatibility, risk, and rollback
+
+- `QWEN_API_KEY` and the legacy complete endpoint remain backward-compatible.
+  `DASHSCOPE_API_KEY` and `QWEN_API_BASE_URL` are additive fallbacks.
+- Explicit `enable_thinking: false` intentionally changes request semantics for
+  this model from provider-default thinking to deterministic non-thinking.
+- The dependency moves to the compatible 0.4 line and excludes 0.5. Public app
+  import paths remain unchanged.
+- Historical flat prices can produce inaccurate cost estimates; callers must
+  treat them as non-authoritative until the related pricing schema lands.
+
+### Rollback
+
+Use a focused revert PR restoring the dependency/lock, Qwen block, tests, and
+documentation together from editor base
+`841c8efa07ba3434f5e5b726d0847be28c567ae5`. Keep app catalog ownership intact.
+If official evidence becomes stale or contradictory before merge, return Issue
+#31 to research rather than guessing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "editor_assistant"
 version = "0.6.0"
 requires-python = ">=3.10"
 dependencies = [
-    "llm-exec-core>=0.3.0,<0.4.0",
+    "llm-exec-core>=0.4.1,<0.5.0",
     "markitdown[all]",
     "requests",  # Deprecated: will be removed after async migration complete
     "httpx>=0.25.0",

--- a/src/editor_assistant/config/llm_config.yml
+++ b/src/editor_assistant/config/llm_config.yml
@@ -166,24 +166,34 @@ gemini:
 # Alibaba Bailian (百炼) — same OpenAI-compatible endpoint as legacy DashScope.
 qwen:
   api_key_env_var: "QWEN_API_KEY"
+  api_key_env_aliases: ["DASHSCOPE_API_KEY"]
   api_base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+  api_base_url_env_var: "QWEN_API_BASE_URL"
   temperature: 0.6
-  max_tokens: 32768
-  context_window: 995904
+  max_tokens: 65536
+  context_window: 1000000
+  # The Chat API still accepts max_tokens; migrate only under a future decision.
+  output_token_field: "max_tokens"
   pricing_currency: "¥"
   models:
     qwen3.6-flash:
       id: "qwen3.6-flash"
+      request_overrides:
+        enable_thinking: false
+      # Historical compatibility placeholders only, not authoritative rates.
+      # Current billing varies by region, token tier, cache, Batch, and mode;
+      # the shared flat schema cannot encode it (related-only core issue #23).
       pricing: {input: 0.30, output: 0.60}
       capabilities:
-        version: "qwen-bailian-2026-07-02"
-        source: "https://help.aliyun.com/zh/model-studio/compatibility-of-openai-with-dashscope"
-        source_date: "2026-07-02"
+        version: "qwen-bailian-2026-07-22"
+        source: "https://help.aliyun.com/en/model-studio/text-generation-model/"
+        source_date: "2026-07-22"
         strict_response_schema: false
-        json_object_response: false
-        tools: false
-        tool_streaming: false
-        tool_choice: false
+        json_object_response: true
+        tools: true
+        tool_streaming: true
+        tool_choice: true
+        parallel_tool_calls: true
         reasoning_controls: []
 
 zhipu:

--- a/tests/unit/test_catalog_ownership.py
+++ b/tests/unit/test_catalog_ownership.py
@@ -42,7 +42,7 @@ EXPECTED_MODELS = [
     "claude-opus-4.8-or",
 ]
 
-CATALOG_SHA256 = (
+RELEASE_CORE_CATALOG_SHA256 = (
     "490c5df6988c43b65badf28f75a8507e09c11505a2d4f47ecb2bda42984abfd4"
 )
 
@@ -70,32 +70,32 @@ def _write_custom_config(tmp_path: Path) -> Path:
     return config_path
 
 
-def _forbid_core_default(monkeypatch, tmp_path: Path) -> None:
-    missing_path = tmp_path / "core-default-must-not-be-used.yml"
-    monkeypatch.setattr(core_config, "_DEFAULT_PROVIDER_SETTINGS", None)
-    monkeypatch.setattr(
-        core_config, "_get_default_config_path", lambda: missing_path
-    )
-
-
-def test_app_catalog_is_exact_core_030_copy():
+def test_app_catalog_is_owned_independently_from_core_041():
     from editor_assistant.config.constants import LLM_CONFIG_PATH
 
     core_catalog_path = Path(core_config.__file__).with_name("llm_config.yml")
     app_bytes = LLM_CONFIG_PATH.read_bytes()
     core_bytes = core_catalog_path.read_bytes()
 
-    assert llm_exec_core.__version__ == "0.3.0"
-    assert app_bytes == core_bytes
-    assert hashlib.sha256(app_bytes).hexdigest() == CATALOG_SHA256
-    assert yaml.safe_load(app_bytes) == yaml.safe_load(core_bytes)
+    assert llm_exec_core.__version__ == "0.4.1"
+    assert (
+        hashlib.sha256(core_bytes).hexdigest() == RELEASE_CORE_CATALOG_SHA256
+    )
+    assert app_bytes != core_bytes
+    assert yaml.safe_load(app_bytes) != yaml.safe_load(core_bytes)
 
 
 def test_catalog_is_available_as_package_data():
+    from editor_assistant.config.constants import LLM_CONFIG_PATH
+
     catalog = files("editor_assistant.config").joinpath("llm_config.yml")
 
     assert catalog.is_file()
-    assert hashlib.sha256(catalog.read_bytes()).hexdigest() == CATALOG_SHA256
+    assert catalog.read_bytes() == LLM_CONFIG_PATH.read_bytes()
+    assert (
+        hashlib.sha256(catalog.read_bytes()).hexdigest()
+        != RELEASE_CORE_CATALOG_SHA256
+    )
 
 
 def test_project_metadata_packages_catalog_and_constrains_core():
@@ -106,25 +106,23 @@ def test_project_metadata_packages_catalog_and_constrains_core():
         .read_text(encoding="utf-8")
     )
 
-    assert '"llm-exec-core>=0.3.0,<0.4.0"' in pyproject
+    assert '"llm-exec-core>=0.4.1,<0.5.0"' in pyproject
     assert '"config/llm_config.yml"' in pyproject
     assert 'path = "../llm-exec-core", editable = true' in pyproject
 
 
 def test_default_discovery_uses_app_catalog_without_key_or_network(
-    monkeypatch, tmp_path
+    monkeypatch,
 ):
+    from editor_assistant.config.constants import LLM_CONFIG_PATH
     from editor_assistant.llm_client import LLMClient
 
-    core_catalog = yaml.safe_load(
-        Path(core_config.__file__)
-        .with_name("llm_config.yml")
-        .read_text(encoding="utf-8")
-    )
-    for provider_name, provider in core_catalog.items():
+    app_catalog = yaml.safe_load(LLM_CONFIG_PATH.read_text(encoding="utf-8"))
+    for provider_name, provider in app_catalog.items():
         if not provider_name.startswith("_"):
             monkeypatch.delenv(provider["api_key_env_var"], raising=False)
-    _forbid_core_default(monkeypatch, tmp_path)
+            for alias in provider.get("api_key_env_aliases", []):
+                monkeypatch.delenv(alias, raising=False)
 
     with (
         patch(
@@ -156,11 +154,10 @@ def test_cli_parser_uses_exact_catalog_and_glm_52_default():
     assert list(model_action.choices) == EXPECTED_MODELS
 
 
-def test_default_client_construction_uses_app_catalog(monkeypatch, tmp_path):
+def test_default_client_construction_uses_app_catalog(monkeypatch):
     from editor_assistant.llm_client import LLMClient
 
     monkeypatch.setenv("ZHIPU_API_KEY_OPENROUTER", "test-key")
-    _forbid_core_default(monkeypatch, tmp_path)
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
@@ -181,7 +178,6 @@ def test_explicit_client_construction_and_discovery_preserve_source(
     if source_kind == "path":
         config_source = _write_custom_config(tmp_path)
     monkeypatch.setenv("CUSTOM_TEST_API_KEY", "test-key")
-    _forbid_core_default(monkeypatch, tmp_path)
 
     client = LLMClient("custom-model", config_source=config_source)
 
@@ -195,11 +191,10 @@ def test_explicit_client_construction_and_discovery_preserve_source(
     "order", [("default", "explicit"), ("explicit", "default")]
 )
 def test_default_and_explicit_discovery_are_isolated_in_both_orders(
-    monkeypatch, tmp_path, order
+    order,
 ):
     from editor_assistant.llm_client import LLMClient
 
-    _forbid_core_default(monkeypatch, tmp_path)
     results = {}
 
     for source_name in order:
@@ -214,17 +209,13 @@ def test_default_and_explicit_discovery_are_isolated_in_both_orders(
     assert results["explicit"] == ["custom-model"]
 
 
-def test_config_compatibility_api_defaults_and_explicit_override(
-    monkeypatch, tmp_path
-):
+def test_config_compatibility_api_defaults_and_explicit_override():
     from editor_assistant.config.llm_models import (
         get_model_details,
         get_provider_settings,
         get_supported_models,
         load_all_settings,
     )
-
-    _forbid_core_default(monkeypatch, tmp_path)
 
     assert get_supported_models() == EXPECTED_MODELS
     settings = load_all_settings()

--- a/tests/unit/test_qwen_catalog.py
+++ b/tests/unit/test_qwen_catalog.py
@@ -1,0 +1,262 @@
+"""Focused offline tests for the app-owned Qwen catalog policy."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from editor_assistant.config.llm_models import (
+    get_model_details,
+    get_supported_models,
+)
+from editor_assistant.llm_client import LLMClient
+
+pytestmark = pytest.mark.unit
+
+PRIMARY_KEY = "QWEN_API_KEY"
+FALLBACK_KEY = "DASHSCOPE_API_KEY"
+ENDPOINT_VARIABLE = "QWEN_API_BASE_URL"
+STATIC_ENDPOINT = (
+    "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+)
+DECISION_RECORD = (
+    Path(__file__).parents[2]
+    / "docs"
+    / "design_docs"
+    / "issue_31_qwen_catalog_decision.md"
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_qwen_environment(monkeypatch):
+    for environment_name in (PRIMARY_KEY, FALLBACK_KEY, ENDPOINT_VARIABLE):
+        monkeypatch.delenv(environment_name, raising=False)
+
+
+def _client(monkeypatch, *, primary=None, fallback=None, endpoint=None):
+    if primary is not None:
+        monkeypatch.setenv(PRIMARY_KEY, primary)
+    if fallback is not None:
+        monkeypatch.setenv(FALLBACK_KEY, fallback)
+    if endpoint is not None:
+        monkeypatch.setenv(ENDPOINT_VARIABLE, endpoint)
+    return LLMClient("qwen3.6-flash")
+
+
+def test_qwen_catalog_has_exact_single_model_and_effective_policy(monkeypatch):
+    qwen_models = [
+        model_name
+        for model_name in get_supported_models()
+        if model_name.startswith("qwen")
+    ]
+    provider, model = get_model_details("qwen3.6-flash")
+    client = _client(monkeypatch, primary="primary-test-key")
+
+    assert qwen_models == ["qwen3.6-flash"]
+    assert model.id == "qwen3.6-flash"
+    assert client.context_window == 1_000_000
+    assert client.max_tokens == 65_536
+    assert client.output_token_field == "max_tokens"
+    assert client.request_overrides == {"enable_thinking": False}
+    assert provider.api_key_env_var == PRIMARY_KEY
+    assert provider.api_key_env_aliases == [FALLBACK_KEY]
+    assert provider.api_base_url_env_var == ENDPOINT_VARIABLE
+    assert provider.api_base_url == STATIC_ENDPOINT
+
+
+def test_qwen_capabilities_and_historical_pricing_are_exact():
+    _, model = get_model_details("qwen3.6-flash")
+
+    assert model.capabilities is not None
+    assert model.capabilities.model_dump() == {
+        "version": "qwen-bailian-2026-07-22",
+        "source": "https://help.aliyun.com/en/model-studio/text-generation-model/",
+        "source_date": "2026-07-22",
+        "strict_response_schema": False,
+        "json_object_response": True,
+        "tools": True,
+        "tool_streaming": True,
+        "tool_choice": True,
+        "parallel_tool_calls": True,
+        "reasoning_controls": [],
+        "openrouter_supported_parameters": [],
+    }
+    assert model.pricing.input == 0.30
+    assert model.pricing.output == 0.60
+
+
+def test_qwen_primary_key_precedes_fallback(monkeypatch):
+    client = _client(
+        monkeypatch,
+        primary="primary-test-key",
+        fallback="fallback-test-key",
+    )
+
+    assert client.api_key == "primary-test-key"
+    assert client.headers["Authorization"] == "Bearer primary-test-key"
+
+
+def test_qwen_falls_back_to_dashscope_key(monkeypatch):
+    client = _client(monkeypatch, fallback="fallback-test-key")
+
+    assert client.api_key == "fallback-test-key"
+    assert client.headers["Authorization"] == "Bearer fallback-test-key"
+
+
+def test_qwen_missing_keys_fail_without_http(monkeypatch):
+    with patch("llm_exec_core.client.httpx.AsyncClient") as async_client:
+        with pytest.raises(ValueError) as error:
+            _client(monkeypatch)
+
+    message = str(error.value)
+    assert PRIMARY_KEY in message
+    assert FALLBACK_KEY in message
+    async_client.assert_not_called()
+
+
+def test_qwen_invalid_key_does_not_leak_secret(monkeypatch):
+    secret = "secret-prefix\nsecret-suffix"
+
+    with pytest.raises(ValueError) as error:
+        _client(monkeypatch, primary=secret, fallback="later-test-key")
+
+    message = str(error.value)
+    assert PRIMARY_KEY in message
+    assert secret not in message
+    assert "secret-prefix" not in message
+    assert "secret-suffix" not in message
+    assert "later-test-key" not in message
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        (
+            "https://workspace.cn-beijing.maas.aliyuncs.com/"
+            "compatible-mode/v1",
+            "https://workspace.cn-beijing.maas.aliyuncs.com/"
+            "compatible-mode/v1/chat/completions",
+        ),
+        (
+            "https://workspace.cn-beijing.maas.aliyuncs.com/"
+            "compatible-mode/v1/chat/completions",
+            "https://workspace.cn-beijing.maas.aliyuncs.com/"
+            "compatible-mode/v1/chat/completions",
+        ),
+    ],
+)
+def test_qwen_endpoint_override_accepts_sdk_and_full_forms(
+    monkeypatch, endpoint, expected
+):
+    client = _client(
+        monkeypatch,
+        primary="primary-test-key",
+        endpoint=endpoint,
+    )
+
+    assert client.api_url == expected
+
+
+def test_qwen_static_endpoint_is_the_unset_override_fallback(monkeypatch):
+    client = _client(monkeypatch, primary="primary-test-key")
+
+    assert client.api_url == STATIC_ENDPOINT
+
+
+def test_qwen_invalid_endpoint_fails_before_http(monkeypatch):
+    with patch("llm_exec_core.client.httpx.AsyncClient") as async_client:
+        with pytest.raises(ValueError) as error:
+            _client(
+                monkeypatch,
+                primary="primary-test-key",
+                endpoint="http://secret-host.invalid/v1",
+            )
+
+    message = str(error.value)
+    assert ENDPOINT_VARIABLE in message
+    assert "secret-host" not in message
+    async_client.assert_not_called()
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_qwen_exact_request_plan_forces_non_thinking(monkeypatch, stream):
+    client = _client(monkeypatch, primary="primary-test-key")
+
+    with patch(
+        "llm_exec_core.client.httpx.AsyncClient",
+        side_effect=AssertionError("request planning must not create HTTP"),
+    ):
+        payload, planning = client._build_request_plan(
+            "Hello", stream, None, None
+        )
+
+    expected = {
+        "model": "qwen3.6-flash",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "temperature": 0.6,
+        "stream": stream,
+        "max_tokens": 65_536,
+        "enable_thinking": False,
+    }
+    if stream:
+        expected["stream_options"] = {"include_usage": True}
+
+    assert payload == expected
+    assert "reasoning_effort" not in payload
+    assert planning["strategy"] == "raw"
+
+
+def test_qwen_json_object_preference_uses_non_strict_fallback(monkeypatch):
+    client = _client(monkeypatch, primary="primary-test-key")
+
+    payload, planning = client._build_request_plan(
+        "Return JSON",
+        False,
+        None,
+        {
+            "schema": {"type": "object"},
+            "mode": "prefer",
+        },
+    )
+
+    assert payload["response_format"] == {"type": "json_object"}
+    assert payload["enable_thinking"] is False
+    assert planning["strategy"] == "json_object"
+    assert planning["fallback_reason"] == "strict_schema_not_supported"
+
+
+def test_qwen_thinking_level_is_rejected_before_http(monkeypatch):
+    monkeypatch.setenv(PRIMARY_KEY, "primary-test-key")
+
+    with patch("llm_exec_core.client.httpx.AsyncClient") as async_client:
+        with pytest.raises(
+            ValueError, match="thinking_level.*reasoning_effort"
+        ):
+            LLMClient("qwen3.6-flash", thinking_level="high")
+
+    async_client.assert_not_called()
+
+
+def test_qwen_decision_record_covers_sources_candidates_and_limitations():
+    record = DECISION_RECORD.read_text(encoding="utf-8")
+
+    for required_text in (
+        "2026-07-22",
+        "https://github.com/lanmogu98/llm-exec-core/releases/tag/0.4.1",
+        "qwen3.6-flash-2026-04-16",
+        "qwen3.7",
+        "qwen3.8",
+        "qwen3.6-plus",
+        "qwen3.6-max",
+        "qwen3.5",
+        "qwen3-max",
+        "qwen-max",
+        "qwen-plus",
+        "qwen-turbo",
+        "max_completion_tokens",
+        "non-authoritative",
+        "llm-exec-core/issues/23",
+        "editor-assistant/issues/20",
+        "Rollback",
+    ):
+        assert required_text in record

--- a/uv.lock
+++ b/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "llm-exec-core"
-version = "0.3.0"
+version = "0.4.1"
 source = { editable = "../llm-exec-core" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Refreshes only the existing `qwen3.6-flash` entry with the accepted non-thinking policy; no Qwen model is added, removed, aliased, or remapped.
- Moves the runtime range to `llm-exec-core>=0.4.1,<0.5.0` while preserving the editable `../llm-exec-core` source and limiting `uv.lock` to the core version change.
- Adds focused offline behavior tests, publication/official-source provenance, pricing limitations, and user-facing documentation.

Closes #31

## Authority and exact head

- Maintainer dispatch: https://github.com/lanmogu98/editor-assistant/issues/31#issuecomment-5042045797
- Publication checkpoint: https://github.com/lanmogu98/editor-assistant/issues/31#issuecomment-5042014797
- Post-publication official-evidence PASS: https://github.com/lanmogu98/editor-assistant/issues/31#issuecomment-5042040555
- Implementation Session: `019f87e5-89c3-7d23-98b5-8f226c060e38`
- Base: `841c8efa07ba3434f5e5b726d0847be28c567ae5`
- Head: `bd7e70125c96d9b2ca9d429656b9a1868f36eb42`
- Core sibling verified clean/detached at tag `0.4.1` target `3014b4b09f2f40db9820fac1f39e6f7c308fb654`; no core file was changed.

## Exact scope

Changed exactly eight files:

- `src/editor_assistant/config/llm_config.yml`
- `pyproject.toml`
- `uv.lock`
- `tests/unit/test_catalog_ownership.py`
- `tests/unit/test_qwen_catalog.py`
- `docs/design_docs/issue_31_qwen_catalog_decision.md`
- `README.md`
- `CHANGELOG.md`

`src/editor_assistant/llm_client.py` is unchanged.

## Tests-first evidence

- Expected RED before implementation: focused command collected 28 tests; **14 failed, 14 passed**. Failures were confined to the old Qwen limits/capabilities, missing key/endpoint/request policy, old core dependency/catalog-ownership assumptions, and absent decision record. All tests were offline and HTTP construction was guarded.
- Focused GREEN: `UV_CACHE_DIR=/private/tmp/editor-assistant-issue31-uv-cache uv run --frozen pytest -q tests/unit/test_qwen_catalog.py tests/unit/test_catalog_ownership.py` → **28 passed**.

## Exact-head canonical verification

All commands were rerun against clean commit `bd7e70125c96d9b2ca9d429656b9a1868f36eb42`:

- `uv sync --locked` → resolved 128; audited 119.
- `uv run --frozen pytest tests/unit/` → **183 passed**.
- `uv run --frozen black --check src/ tests/` → **53 files unchanged** (Black emitted its existing Python 3.13/3.14 parser warning; exit 0).
- `uv run --frozen flake8 src/` → pass.
- `uv run --frozen mypy src/` → pass, 24 source files.
- `uv build` → built wheel and sdist.
- `uv lock --check` and `git diff --check` → pass.

No provider/live integration test, credential lookup, or HTTP provider call was run.

## Lock and artifact proof

- `pyproject.toml`: only `llm-exec-core>=0.3.0,<0.4.0` → `llm-exec-core>=0.4.1,<0.5.0`.
- `uv.lock`: only root editable core version `0.3.0` → `0.4.1`; source remains `{ editable = "../llm-exec-core" }`; no package/source/resolution drift.
- Wheel and sdist both contain `editor_assistant/config/llm_config.yml`.
- Wheel and sdist metadata both declare `Requires-Dist: llm-exec-core<0.5.0,>=0.4.1`.
- Source, wheel, and sdist catalog bytes share SHA-256 `65b97a4b5c9fa6f25b58b99e3f7919c5a14e7fb1a858f1a18fa92b7c56c421b7`.

## Isolated wheel smoke

- Downloaded the public GitHub Release core wheel first: 24,243 bytes; SHA-256 `30dbc41afa29cf1e74d572703a93111f65ab7581eae4d69d739fe292d007e6f7`.
- In a fresh Python 3.13 venv, installed that wheel, then the exact-head editor wheel; the final proof reran offline from the populated cache.
- Runtime: `editor-assistant==0.6.0`, `llm-exec-core==0.4.1`; both module paths resolve inside the isolated venv, not `../llm-exec-core`.
- Installed METADATA range matches; installed catalog digest matches; Qwen keys are exactly `qwen3.6-flash`; effective policy is `(1000000, 65536, False)`.

## Compatibility, risk, and review

- `QWEN_API_KEY` remains primary; `DASHSCOPE_API_KEY` is fallback; `QWEN_API_BASE_URL` accepts SDK-base/full-endpoint forms; the existing full endpoint remains fallback.
- Explicit `enable_thinking: false` is intentional. No reasoning-effort mapping is advertised.
- Retained flat prices are historical, non-authoritative placeholders; related core #23 remains non-blocking.
- Independent high-risk review is intentionally not self-authored and remains for a separate reviewer.
- Exact-head GitHub readback after PR creation: PR is open, ready, mergeable, and still targets base `841c8efa07ba3434f5e5b726d0847be28c567ae5` from head `bd7e70125c96d9b2ca9d429656b9a1868f36eb42`; combined statuses are `[]` and PR-triggered workflow runs are `[]`. No GitHub check is pending or reported for this SHA, consistent with the dispatch's no-check configuration readback.

## Rollback

Use a focused revert PR restoring the dependency/lock, Qwen block, tests, and documentation together from editor base `841c8efa07ba3434f5e5b726d0847be28c567ae5`. Keep app catalog ownership intact. If official evidence becomes stale or contradictory before merge, return Issue #31 to research rather than guessing.
