### PR TITLE
feat: add typed task execution results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Documented downstream package contract for LinkResearcher and other workers.
 - Added the dated Qwen/Bailian catalog decision record for Issue #31.
+- Added JSON-aware `OutputArtifact`, success-only `TaskExecutionResult`, and `MDProcessor.execute_task()` while preserving the legacy task wrappers.
 
 ### Changed
 - Editor Assistant continues to package and own its 21-model catalog while using `llm-exec-core` 0.4.1 for schema validation, generic connection resolution, effective model policy, and execution. Library callers may provide an explicit path or dictionary `config_source` without sharing the app default.
 - Changed the CLI/library migration default from `glm-4.7-or` to `glm-5.2-or`. Removed names such as `glm-4.7-or` and `glm-4.6-or` are not restored or mapped.
-- Constrained the runtime dependency to `llm-exec-core>=0.4.1,<0.5.0` while retaining the sibling editable source for development.
+- Locked the runtime dependency to the reviewed `llm-exec-core` 0.4.1 GitHub release artifact instead of a sibling editable checkout.
 - Refreshed only `qwen3.6-flash`: non-thinking requests are explicit, connection key/endpoint fallbacks are configurable, context/output limits are 1M/64K, and supported JSON/tool capabilities are recorded without adding Qwen models.
 - Retained Qwen's historical `¥0.30`/`¥0.60` flat prices only as non-authoritative compatibility placeholders pending tiered-pricing schema work in related-only `llm-exec-core` #23.
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -32,14 +32,11 @@ This document provides technical documentation for developers contributing to Ed
 
 `llm-exec-core` now owns the model catalog (`llm_exec_core/llm_config.yml`), provider config loading, HTTP transport, streaming assembly, and token accounting. Editor Assistant uses that package as a dependency and keeps ownership of document workflow, task definitions, prompt templates, SQLite persistence, CLI behavior, output paths, and application logging.
 
-For this migration branch, the committed dependency mode is intentionally local and coordinated across two repos:
-
-```toml
-[tool.uv.sources]
-llm-exec-core = { path = "../llm-exec-core", editable = true }
-```
-
-Keep that relative source for sibling checkout and CI workspace runs on this branch. The publish/release step happens later: after `llm-exec-core` is published, remove `[tool.uv.sources]` and pin `llm-exec-core==0.1.0`.
+The committed dependency is the reviewed `llm-exec-core` 0.4.1 GitHub release
+wheel. `uv.lock` records the release URL and SHA-256
+`30dbc41afa29cf1e74d572703a93111f65ab7581eae4d69d739fe292d007e6f7`.
+Development, validation, and CI must use that locked release artifact rather
+than a sibling or editable core checkout.
 
 ---
 
@@ -66,7 +63,7 @@ Keep that relative source for sibling checkout and CI workspace runs on this bra
 ┌────────────────────────────┐     ┌──────────────────────────────────┐
 │    Content Conversion      │     │       Content Processing         │
 │    (md_converter.py)       │     │       (md_processor.py)          │
-│    - PDF, DOCX, HTML       │ --> │       [Async] process_mds()      │
+│    - PDF, DOCX, HTML       │ --> │ [Async] execute_task/process_mds │
 │    - URL fetching          │     │       - Prompt building          │
 │    - Format detection      │     │       - Semaphore control        │
 │    [Sync] (CPU Bound)      │     │       - Output formatting        │
@@ -98,9 +95,10 @@ Keep that relative source for sibling checkout and CI workspace runs on this bra
 Input (URL/PDF/MD) 
     → MarkdownConverter.convert_content() [Sync] (or direct `.md` read)
     → MDArticle (normalized content)
-    → EditorAssistant.process_multiple() [Async Fan-out]
-    → MDProcessor.process_mds() [Async] (Semaphore-limited)
-    → editor_assistant.llm_client.LLMClient.generate_response() [Async shim to llm_exec_core]
+    → EditorAssistant.process_multiple() [legacy async fan-out]
+    → MDProcessor.process_mds() → LLMClient.generate_response() [legacy tuple]
+or
+MDArticle → MDProcessor.execute_task() → LLMClient.generate() [typed result]
     → Output (SQLite run history + optional files under `llm_summaries/`)
 ```
 
@@ -115,11 +113,11 @@ Input (URL/PDF/MD)
 | `cli.py` | Async Command-line interface | `main()`, `create_parser()`, `cmd_generate_brief()` (async), `cmd_resume()` (async), `cmd_export()` |
 | `main.py` | Async Orchestration | `EditorAssistant` |
 | `md_converter.py` | Format conversion (Sync) | `MarkdownConverter` |
-| `md_processor.py` | Async LLM processing | `MDProcessor` (uses `asyncio.Semaphore`) |
+| `md_processor.py` | Async LLM processing | `MDProcessor.execute_task()`, compatibility `process_mds()` |
 | `llm_client.py` | Legacy import shim for extracted client | `LLMClient` re-export from `llm_exec_core.client` |
 | `clean_html_to_md.py` | HTML extraction | `CleanHTML2Markdown` |
 | `content_validation.py` | Input validation | `validate_content()`, `BlockedPublisherError` |
-| `data_models.py` | Data structures | `MDArticle`, `Input`, `ProcessType`, `InputType` |
+| `data_models.py` | Data structures | `MDArticle`, `OutputArtifact`, `TaskExecutionResult`, `Input`, `ProcessType`, `InputType` |
 
 ### Config Modules
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,10 @@ Editor Assistant is an AI-powered Python CLI and library for turning research pa
 
 Editor Assistant uses `llm-exec-core` for catalog schema and loading, provider routing, token accounting, and HTTP execution. The app layer owns the packaged default model catalog as well as document workflow, tasks, prompts, SQLite storage, CLI commands, output paths, and app logging.
 
-This branch is a coordinated two-repo/local-migration branch. Keep the current sibling-checkout dependency mode:
-
-```toml
-[tool.uv.sources]
-llm-exec-core = { path = "../llm-exec-core", editable = true }
-```
-
-That relative source remains intentional for local development and workspace checkouts that test both repos together. Published installs use the declared `llm-exec-core>=0.4.1,<0.5.0` compatibility range; the editable source does not change that package boundary.
+Editor Assistant consumes the reviewed `llm-exec-core` 0.4.1 GitHub release
+wheel directly. `uv.lock` pins the published artifact with SHA-256
+`30dbc41afa29cf1e74d572703a93111f65ab7581eae4d69d739fe292d007e6f7`;
+no sibling or editable core checkout is used.
 
 ### Features
 
@@ -44,7 +40,8 @@ cd editor-assistant
 uv sync
 ```
 
-On this migration branch, `uv sync` expects a sibling checkout at `../llm-exec-core` because `pyproject.toml` uses a relative `[tool.uv.sources]` entry. In CI, use a workspace layout that checks out both repos side by side.
+`uv sync` resolves the locked `llm-exec-core` release artifact without a
+sibling repository checkout.
 
 For a runtime-only environment:
 
@@ -282,6 +279,43 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+For already-converted documents, `MDProcessor.execute_task()` is the additive
+typed Python entry point. It returns a success-only `TaskExecutionResult` with
+named `OutputArtifact` values and the original core `LLMResult`, including
+`text`, `structured`, typed usage, and planning metadata. Validation, provider,
+and post-processing exceptions propagate. The existing `process_mds()` tuple
+and `EditorAssistant.process_multiple()` behavior remain compatibility APIs.
+
+```python
+from pathlib import Path
+
+from editor_assistant.data_models import InputType, MDArticle, ProcessType
+from editor_assistant.md_processor import MDProcessor
+
+processor = MDProcessor("glm-5.2-or", stream=False)
+result = await processor.execute_task(
+    [
+        MDArticle(
+            type=InputType.PAPER,
+            content=Path("paper.md").read_text(encoding="utf-8"),
+            title="Paper",
+            source_path="paper.md",
+        )
+    ],
+    ProcessType.OUTLINE,
+    output_to_console=False,
+)
+
+print(result.outputs["main"].serialized_text)
+print(result.llm_result.usage.total_tokens)
+print(result.llm_result.metadata.planning)
+```
+
+The current `brief`, `outline`, and `translate` tasks remain text tasks and
+produce `text/plain` artifacts. `OutputArtifact` can also represent a typed JSON
+value as `application/json`; schema-aware task configuration is intentionally
+outside this API addition.
+
 ### Supported Input Formats
 
 The converter supports common document and web formats through MarkItDown plus local HTML extraction helpers:
@@ -355,14 +389,10 @@ Editor Assistant 是一个 AI 驱动的 Python CLI 和库，用于把研究论�
 
 Editor Assistant 使用 `llm-exec-core` 提供模型目录 schema 与加载、provider 路由、token 统计和 HTTP 执行能力；应用层拥有打包的默认模型目录，同时继续负责文档工作流、任务、prompt、SQLite 持久化、CLI、输出路径和应用日志。
 
-当前分支是一个双仓协同的本地迁移分支，必须保留 sibling checkout 的依赖方式：
-
-```toml
-[tool.uv.sources]
-llm-exec-core = { path = "../llm-exec-core", editable = true }
-```
-
-这个相对路径仍用于本地开发和双仓 workspace checkout。发布安装遵循声明的 `llm-exec-core>=0.4.1,<0.5.0` 兼容范围；editable source 不会改变该包边界。
+Editor Assistant 直接使用经过评审的 `llm-exec-core` 0.4.1 GitHub 发布
+wheel。`uv.lock` 以 SHA-256
+`30dbc41afa29cf1e74d572703a93111f65ab7581eae4d69d739fe292d007e6f7`
+锁定该发布产物，不再依赖 sibling 或 editable core checkout。
 
 ### 功能特色
 
@@ -387,7 +417,7 @@ cd editor-assistant
 uv sync
 ```
 
-在这个迁移分支上，`uv sync` 依赖 `../llm-exec-core` 这个 sibling checkout，因为 `pyproject.toml` 中使用了相对 `[tool.uv.sources]`。CI 也需要采用双仓并排 checkout 的 workspace 布局。
+`uv sync` 会直接解析锁定的 `llm-exec-core` 发布产物，不需要相邻仓库。
 
 仅安装运行依赖：
 
@@ -623,6 +653,42 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+对于已经转换为 Markdown 的文档，`MDProcessor.execute_task()` 是新增的带
+类型 Python 入口。它只在成功时返回 `TaskExecutionResult`，其中包含具名
+`OutputArtifact` 和原始 core `LLMResult`，因此会保留 `text`、`structured`、
+带类型 usage 和 planning metadata。校验、provider 与后处理异常会继续向上
+抛出；现有 `process_mds()` 元组和 `EditorAssistant.process_multiple()` 行为
+仍作为兼容 API 保留。
+
+```python
+from pathlib import Path
+
+from editor_assistant.data_models import InputType, MDArticle, ProcessType
+from editor_assistant.md_processor import MDProcessor
+
+processor = MDProcessor("glm-5.2-or", stream=False)
+result = await processor.execute_task(
+    [
+        MDArticle(
+            type=InputType.PAPER,
+            content=Path("paper.md").read_text(encoding="utf-8"),
+            title="Paper",
+            source_path="paper.md",
+        )
+    ],
+    ProcessType.OUTLINE,
+    output_to_console=False,
+)
+
+print(result.outputs["main"].serialized_text)
+print(result.llm_result.usage.total_tokens)
+print(result.llm_result.metadata.planning)
+```
+
+当前 `brief`、`outline` 与 `translate` 仍是文本任务，并产生 `text/plain`
+artifact。`OutputArtifact` 也能以 `application/json` 表示带类型 JSON 值；
+schema-aware task 配置不属于本次 API 增量范围。
 
 ### 支持的输入格式
 

--- a/docs/design_docs/issue_24_llm_exec_core_contract.md
+++ b/docs/design_docs/issue_24_llm_exec_core_contract.md
@@ -5,24 +5,27 @@
 - Distribution: `llm-exec-core`
 - Import package: `llm_exec_core`
 - Initial package version: `0.1.0`
+- Reviewed typed-result release: `0.4.1`
 - First editor-assistant consumer version: `0.6.0`
 
 ## Reference Strategy
 
-During local migration, `editor-assistant` references the sibling package with relative `[tool.uv.sources]` or a uv workspace.
-
-For release consumption, applications pin `llm-exec-core==0.1.0`.
-
-Final committed `editor-assistant` config must not contain absolute `file://` paths. Local development uses relative `[tool.uv.sources]` or a uv workspace; release consumption uses the pinned package.
+`editor-assistant` consumes the published 0.4.1 wheel from the GitHub release
+and records its SHA-256
+`30dbc41afa29cf1e74d572703a93111f65ab7581eae4d69d739fe292d007e6f7`
+in `uv.lock`. The committed project and lock files contain no sibling,
+editable, or unreleased core source.
 
 ## Minimal Worker Import
 
 ```python
+from pathlib import Path
+
 from llm_exec_core import LLMClient
 
 
-async def run_llm_step(prompt: str) -> str:
-    client = LLMClient("glm-4.7-or")
+async def run_llm_step(prompt: str, catalog: Path) -> str:
+    client = LLMClient("glm-5.2-or", config_source=catalog)
     result = await client.generate(
         prompt,
         request_name="linkresearcher_ingest",
@@ -40,6 +43,28 @@ async def run_llm_step(prompt: str) -> str:
 - `usage`: token counts, costs, and currency.
 - `metadata`: request id, run id, model, provider, timing, and trace context.
 - `structured`: parsed caller-owned structured output, or `None`.
+
+## Editor Task Result
+
+`MDProcessor.execute_task()` is the additive typed Editor entry point. On
+success it returns `TaskExecutionResult` with:
+
+- `task_name`: the resolved registry task name.
+- `run_id`: the Editor persistence run id.
+- `outputs`: a mapping of output names to `OutputArtifact` values.
+- `llm_result`: the original core `LLMResult` object.
+
+`OutputArtifact` retains a typed string or JSON value, an explicit
+`text/plain` or `application/json` content type, and its serialized text. The
+existing `brief`, `outline`, and `translate` tasks remain text-only and produce
+text artifacts without prompt or output changes.
+
+The typed entry point calls core `generate()` and propagates validation,
+provider, and post-processing exceptions. `process_mds() -> tuple[bool, int]`
+continues using the legacy `generate_response()` adapter and translates the
+same expected failures to its existing boolean/run-id result.
+`EditorAssistant.process_multiple()` remains a `None`-returning compatibility
+orchestrator over `process_mds()`.
 
 ## Execution Metadata Boundary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "editor_assistant"
 version = "0.6.0"
 requires-python = ">=3.10"
 dependencies = [
-    "llm-exec-core>=0.4.1,<0.5.0",
+    "llm-exec-core @ https://github.com/lanmogu98/llm-exec-core/releases/download/0.4.1/llm_exec_core-0.4.1-py3-none-any.whl",
     "markitdown[all]",
     "requests",  # Deprecated: will be removed after async migration complete
     "httpx>=0.25.0",
@@ -44,6 +44,3 @@ line-length = 79
 # include runtime configuration in the package
 [tool.setuptools]
 package-data = { "editor_assistant" = ["config/llm_config.yml", "config/prompts/*.txt"] }
-
-[tool.uv.sources]
-llm-exec-core = { path = "../llm-exec-core", editable = true }

--- a/src/editor_assistant/data_models.py
+++ b/src/editor_assistant/data_models.py
@@ -1,9 +1,24 @@
 # This file contains the data models for the project.
 
-from pydantic import BaseModel, ConfigDict
-from typing import Optional
+from __future__ import annotations
+
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Literal, Mapping, Optional, TypeAlias
+
+from llm_exec_core import LLMResult
+from pydantic import BaseModel, ConfigDict
+
+JSONValue: TypeAlias = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | list["JSONValue"]
+    | dict[str, "JSONValue"]
+)
 
 
 # for the input source data
@@ -52,6 +67,25 @@ class MDArticle(BaseModel):
     output_path: Optional[Path] = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)  # Allow Path type
+
+
+@dataclass(slots=True)
+class OutputArtifact:
+    """A typed task output and its stable serialized representation."""
+
+    value: str | JSONValue
+    content_type: Literal["text/plain", "application/json"]
+    serialized_text: str
+
+
+@dataclass(slots=True)
+class TaskExecutionResult:
+    """Successful task execution with Editor and core result metadata."""
+
+    task_name: str
+    run_id: int
+    outputs: Mapping[str, OutputArtifact]
+    llm_result: LLMResult
 
 
 class SaveType(str, Enum):

--- a/src/editor_assistant/md_processor.py
+++ b/src/editor_assistant/md_processor.py
@@ -29,10 +29,16 @@ from .config.constants import (
 )
 
 # for LLM processing
-from .llm_client import LLMClient
+from .llm_client import LLMClient, LLMResult
 
 # for data models
-from .data_models import MDArticle, ProcessType, SaveType
+from .data_models import (
+    MDArticle,
+    OutputArtifact,
+    ProcessType,
+    SaveType,
+    TaskExecutionResult,
+)
 
 # for the pluggable task system
 from .tasks import TaskRegistry, Task
@@ -130,6 +136,31 @@ class MDProcessor:
         # Concurrency control
         self._semaphore = asyncio.Semaphore(max_concurrent)
 
+    async def execute_task(
+        self,
+        md_articles: List[MDArticle],
+        task_type: Union[ProcessType, str],
+        output_to_console: bool = True,
+        save_files: bool = False,
+        stream_callback: Optional[Callable[[str], None]] = None,
+    ) -> TaskExecutionResult:
+        """Execute a task and return its successful typed result.
+
+        Validation, provider, and post-processing exceptions propagate to
+        typed callers.
+        """
+        result = await self._execute_task(
+            md_articles,
+            task_type,
+            output_to_console=output_to_console,
+            save_files=save_files,
+            stream_callback=stream_callback,
+            use_legacy_client=False,
+        )
+        if result is None:
+            raise RuntimeError("Typed task execution produced no result.")
+        return result
+
     async def process_mds(
         self,
         md_articles: List[MDArticle],
@@ -138,6 +169,41 @@ class MDProcessor:
         save_files: bool = False,
         stream_callback: Optional[Callable[[str], None]] = None,
     ) -> tuple[bool, int]:
+        """Compatibility wrapper returning the legacy success tuple."""
+        run_id = -1
+
+        def remember_run_id(value: int) -> None:
+            nonlocal run_id
+            run_id = value
+
+        try:
+            await self._execute_task(
+                md_articles,
+                task_type,
+                output_to_console=output_to_console,
+                save_files=save_files,
+                stream_callback=stream_callback,
+                use_legacy_client=True,
+                on_run_created=remember_run_id,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return False, run_id
+
+        return True, run_id
+
+    async def _execute_task(
+        self,
+        md_articles: List[MDArticle],
+        task_type: Union[ProcessType, str],
+        output_to_console: bool,
+        save_files: bool,
+        stream_callback: Optional[Callable[[str], None]],
+        *,
+        use_legacy_client: bool,
+        on_run_created: Optional[Callable[[int], None]] = None,
+    ) -> Optional[TaskExecutionResult]:
         """
         Process documents using the pluggable task system (Async).
 
@@ -158,10 +224,11 @@ class MDProcessor:
         task_cls = TaskRegistry.get(task_name)
         if task_cls is None:
             available_tasks = TaskRegistry.list_tasks()
-            error(
+            message = (
                 f"Unknown task type: {task_name}. Available: {available_tasks}"
             )
-            return False, run_id
+            error(message)
+            raise ValueError(message)
 
         # Instantiate task
         task: Task = task_cls()
@@ -169,8 +236,9 @@ class MDProcessor:
         # Validate inputs (task-level)
         is_valid, err_msg = task.validate(md_articles)
         if not is_valid:
-            error(f"Validation failed for {task_name}: {err_msg}")
-            return False, run_id
+            message = f"Validation failed for {task_name}: {err_msg}"
+            error(message)
+            raise ValueError(message)
 
         # Content validation per article
         for md_article in md_articles:
@@ -187,14 +255,15 @@ class MDProcessor:
                 if warn_msg:
                     warning(warn_msg)
                 if not is_content_valid:
-                    error(
+                    message = (
                         "Content invalid for "
                         f"{md_article.title or 'Untitled'}: {warn_msg}"
                     )
-                    return False, run_id
+                    error(message)
+                    raise ValueError(message)
             except BlockedPublisherError as e:
                 error(f"Blocked publisher: {e}")
-                return False, run_id
+                raise
 
         # Context budget check
         for md_article in md_articles:
@@ -202,7 +271,7 @@ class MDProcessor:
                 check_context_budget(md_article.content or "", self.llm_client)
             except ContentTooLargeError as e:
                 error(f"Content too large: {md_article.title}: {str(e)}")
-                return False, run_id
+                raise
 
         # Create run record in database (Async via thread pool)
         # Offload synchronous DB write to prevent blocking the event loop
@@ -213,6 +282,8 @@ class MDProcessor:
         except Exception as e:
             self.logger.warning(f"Async DB creation failed, falling back: {e}")
             run_id = self._create_run_record(md_articles, task_name)
+        if on_run_created is not None:
+            on_run_created(run_id)
 
         # Create base title
         title_base = (
@@ -247,16 +318,17 @@ class MDProcessor:
             prompt = task.build_prompt(md_articles)
         except Exception as e:
             error(f"Failed to build prompt: {e}")
-            return False, run_id
+            raise
 
         # Check prompt size
         try:
             check_context_budget(prompt, self.llm_client)
         except ContentTooLargeError as e:
             error(f"Prompt too large: {str(e)}")
-            return False, run_id
+            raise
 
         # Make LLM request (Async with Semaphore)
+        llm_result: Optional[LLMResult] = None
         try:
             progress(f"Processing document with {len(prompt)} characters...")
             async with self._semaphore:
@@ -280,24 +352,33 @@ class MDProcessor:
 
                     final_callback = suppress_output
 
-                response, usage_stats = await self._make_api_request(
-                    prompt,
-                    task_name,
-                    stream=self.stream,
-                    stream_callback=final_callback,
-                )
+                if use_legacy_client:
+                    response, usage_stats = await self._make_api_request(
+                        prompt,
+                        task_name,
+                        stream=self.stream,
+                        stream_callback=final_callback,
+                    )
+                else:
+                    llm_result = await self._make_typed_api_request(
+                        prompt,
+                        task_name,
+                        stream=self.stream,
+                        stream_callback=final_callback,
+                    )
+                    response, usage_stats = llm_result.to_legacy_tuple()
                 if app_prints_stream:
                     print(flush=True)
-        except Exception as e:
-            error(f"Error making API request: {str(e)}")
-            await asyncio.to_thread(
-                self._update_run_status, run_id, "failed", str(e)
-            )
-            return False, run_id
         except asyncio.CancelledError:
             warning(f"Run {run_id} cancelled during API request")
             await asyncio.to_thread(
                 self._update_run_status, run_id, "aborted", "Cancelled by user"
+            )
+            raise
+        except Exception as e:
+            error(f"Error making API request: {str(e)}")
+            await asyncio.to_thread(
+                self._update_run_status, run_id, "failed", str(e)
             )
             raise
 
@@ -320,7 +401,7 @@ class MDProcessor:
             await asyncio.to_thread(
                 self._update_run_status, run_id, "failed", str(e)
             )
-            return False, run_id
+            raise
 
         # Save all outputs
         should_print = output_to_console and not self.stream
@@ -356,16 +437,16 @@ class MDProcessor:
                     self._save_output_to_db, run_id, output_name, content
                 )
 
-        except Exception as e:
-            error(f"Error saving response: {str(e)}")
-            await asyncio.to_thread(
-                self._update_run_status, run_id, "failed", str(e)
-            )
-            return False, run_id
         except asyncio.CancelledError:
             warning(f"Run {run_id} cancelled during saving")
             await asyncio.to_thread(
                 self._update_run_status, run_id, "aborted", "Cancelled by user"
+            )
+            raise
+        except Exception as e:
+            error(f"Error saving response: {str(e)}")
+            await asyncio.to_thread(
+                self._update_run_status, run_id, "failed", str(e)
             )
             raise
 
@@ -384,7 +465,23 @@ class MDProcessor:
         # Mark run as successful (Async via thread pool)
         await asyncio.to_thread(self._update_run_status, run_id, "success")
 
-        return True, run_id
+        if llm_result is None:
+            return None
+
+        artifacts = {
+            output_name: OutputArtifact(
+                value=content,
+                content_type="text/plain",
+                serialized_text=content,
+            )
+            for output_name, content in outputs.items()
+        }
+        return TaskExecutionResult(
+            task_name=task_name,
+            run_id=run_id,
+            outputs=artifacts,
+            llm_result=llm_result,
+        )
 
     # save content to a file
     def _save_content(
@@ -415,6 +512,21 @@ class MDProcessor:
         except IOError as e:
             error(f"Error saving content: {str(e)}")
             raise
+
+    async def _make_typed_api_request(
+        self,
+        prompt: str,
+        request_name: str,
+        stream: bool = False,
+        stream_callback: Optional[Callable[[str], None]] = None,
+    ) -> LLMResult:
+        """Make an API request and preserve the core typed result."""
+        return await self.llm_client.generate(
+            prompt,
+            request_name,
+            stream=stream,
+            stream_callback=stream_callback,
+        )
 
     async def _make_api_request(
         self,

--- a/tests/unit/test_catalog_ownership.py
+++ b/tests/unit/test_catalog_ownership.py
@@ -98,17 +98,25 @@ def test_catalog_is_available_as_package_data():
     )
 
 
-def test_project_metadata_packages_catalog_and_constrains_core():
-    pyproject = (
-        Path(__file__)
-        .parents[2]
-        .joinpath("pyproject.toml")
-        .read_text(encoding="utf-8")
+def test_project_metadata_packages_catalog_and_uses_released_core():
+    project_root = Path(__file__).parents[2]
+    pyproject = project_root.joinpath("pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    lockfile = project_root.joinpath("uv.lock").read_text(encoding="utf-8")
+    release_url = (
+        "https://github.com/lanmogu98/llm-exec-core/releases/download/"
+        "0.4.1/llm_exec_core-0.4.1-py3-none-any.whl"
     )
 
-    assert '"llm-exec-core>=0.4.1,<0.5.0"' in pyproject
+    assert f'"llm-exec-core @ {release_url}"' in pyproject
     assert '"config/llm_config.yml"' in pyproject
-    assert 'path = "../llm-exec-core", editable = true' in pyproject
+    assert 'path = "../llm-exec-core", editable = true' not in pyproject
+    assert f'source = {{ url = "{release_url}" }}' in lockfile
+    assert (
+        "sha256:30dbc41afa29cf1e74d572703a93111f65ab7581eae4d69d739fe292d007e6f7"
+        in lockfile
+    )
 
 
 def test_default_discovery_uses_app_catalog_without_key_or_network(

--- a/tests/unit/test_data_models.py
+++ b/tests/unit/test_data_models.py
@@ -3,6 +3,7 @@ Unit tests for data models.
 """
 
 import pytest
+import editor_assistant.data_models as data_models
 from editor_assistant.data_models import (
     InputType,
     Input,
@@ -106,3 +107,22 @@ class TestSaveType:
         """Test that SaveType has expected values."""
         assert SaveType.PROMPT.value == "prompt"
         assert SaveType.RESPONSE.value == "response"
+
+
+class TestOutputArtifact:
+    """Test typed task output artifacts."""
+
+    @pytest.mark.unit
+    def test_output_artifact_represents_json_without_flattening_value(self):
+        """JSON artifacts retain both the typed value and serialization."""
+        value = {"items": [1, True, None]}
+
+        artifact = data_models.OutputArtifact(
+            value=value,
+            content_type="application/json",
+            serialized_text='{"items":[1,true,null]}',
+        )
+
+        assert artifact.value is value
+        assert artifact.content_type == "application/json"
+        assert artifact.serialized_text == '{"items":[1,true,null]}'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -95,3 +95,38 @@ async def test_process_multiple_partial_fail_warns_but_processes(
         # Ensure warning emitted for failed input (printed to stdout)
         captured = capsys.readouterr().out
         assert "failed" in captured.lower() or "Failed" in captured
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_process_multiple_keeps_legacy_none_and_done_callback():
+    """The orchestration wrapper keeps its existing public result contract."""
+    article = MDArticle(
+        type=InputType.PAPER,
+        content="Content. " * 500,
+        title="good",
+        source_path="good.pdf",
+    )
+    done_callback = MagicMock()
+
+    with (
+        patch("editor_assistant.main.MarkdownConverter"),
+        patch("editor_assistant.main.MDProcessor") as processor_cls,
+    ):
+        processor = processor_cls.return_value
+        processor.llm_client.model_name = "test-model"
+        processor.process_mds = AsyncMock(return_value=(True, 123))
+        assistant = EditorAssistant("test-model", stream=False)
+        assistant._process_input_to_article = AsyncMock(
+            return_value=(article, None)
+        )
+
+        result = await assistant.process_multiple(
+            [Input(type=InputType.PAPER, path="good.pdf")],
+            "brief",
+            done_callback=done_callback,
+        )
+
+    assert result is None
+    processor.process_mds.assert_awaited_once()
+    done_callback.assert_called_once_with("good.pdf", True)

--- a/tests/unit/test_typed_task_results.py
+++ b/tests/unit/test_typed_task_results.py
@@ -1,0 +1,208 @@
+"""Focused tests for additive typed task execution results."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from llm_exec_core import ExecutionMetadata, LLMResult, TokenUsage
+
+from editor_assistant import data_models
+from editor_assistant.data_models import InputType, MDArticle
+from editor_assistant.md_processor import MDProcessor
+from editor_assistant.tasks.brief import BriefTask
+
+pytestmark = pytest.mark.unit
+
+
+def _core_result() -> LLMResult:
+    return LLMResult(
+        text="Typed response",
+        structured={"title": "Typed title"},
+        usage=TokenUsage(
+            input_tokens=10,
+            output_tokens=20,
+            total_tokens=30,
+            input_cost=0.1,
+            output_cost=0.2,
+            total_cost=0.3,
+            currency="$",
+            requests=[],
+            process_times={"request_times": []},
+        ),
+        metadata=ExecutionMetadata(
+            request_id="request-1",
+            run_id="core-run-1",
+            request_name="brief",
+            model_name="test-model",
+            model_id="test-model-id",
+            provider_name="fake-provider",
+            started_at="2026-07-22T00:00:00",
+            finished_at="2026-07-22T00:00:01",
+            duration_seconds=1.0,
+            trace_context={"source": "unit-test"},
+            planning={"validation_status": "client_validated"},
+        ),
+    )
+
+
+def _legacy_usage() -> dict:
+    return {
+        "total_input_tokens": 10,
+        "total_output_tokens": 20,
+        "cost": {
+            "input_cost": 0.1,
+            "output_cost": 0.2,
+            "total_cost": 0.3,
+        },
+        "process_times": {"total_time": 1.0},
+    }
+
+
+@pytest.fixture
+def processor_dependencies():
+    with (
+        patch("editor_assistant.md_processor.LLMClient") as client_cls,
+        patch("editor_assistant.md_processor.RunRepository") as repo_cls,
+    ):
+        client = MagicMock()
+        client.model_name = "test-model"
+        client.context_window = 100000
+        client.max_tokens = 1000
+        client.pricing_currency = "$"
+        client.generate = AsyncMock(return_value=_core_result())
+        client.generate_response = AsyncMock(
+            return_value=("Legacy response", _legacy_usage())
+        )
+        client_cls.return_value = client
+
+        repository = MagicMock()
+        repository.get_or_create_input.return_value = 456
+        repository.create_run.return_value = 123
+        repo_cls.return_value = repository
+
+        yield MDProcessor("test-model", stream=False), client, repository
+
+
+@pytest.fixture
+def valid_article() -> MDArticle:
+    return MDArticle(
+        type=InputType.PAPER,
+        content="# Test\n\n" + "Content. " * 500,
+        title="Test article",
+        source_path="test.md",
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_task_returns_artifacts_and_raw_core_result(
+    processor_dependencies, valid_article
+):
+    processor, client, _ = processor_dependencies
+    raw_result = _core_result()
+    client.generate.return_value = raw_result
+
+    result = await processor.execute_task(
+        [valid_article], "brief", output_to_console=False
+    )
+
+    assert isinstance(result, data_models.TaskExecutionResult)
+    assert result.task_name == "brief"
+    assert result.run_id == 123
+    assert result.outputs == {
+        "main": data_models.OutputArtifact(
+            value="Typed response",
+            content_type="text/plain",
+            serialized_text="Typed response",
+        )
+    }
+    assert result.llm_result is raw_result
+    assert result.llm_result.structured == {"title": "Typed title"}
+    assert result.llm_result.usage.total_tokens == 30
+    assert result.llm_result.metadata.planning == {
+        "validation_status": "client_validated"
+    }
+    client.generate_response.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_task_propagates_provider_failure(
+    processor_dependencies, valid_article
+):
+    processor, client, repository = processor_dependencies
+    client.generate.side_effect = ConnectionError("provider unavailable")
+
+    with pytest.raises(ConnectionError, match="provider unavailable"):
+        await processor.execute_task(
+            [valid_article], "brief", output_to_console=False
+        )
+
+    repository.update_run_status.assert_any_call(
+        123, "failed", "provider unavailable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_task_propagates_post_processing_failure(
+    processor_dependencies, valid_article
+):
+    processor, _, repository = processor_dependencies
+
+    with patch.object(
+        BriefTask,
+        "post_process",
+        side_effect=RuntimeError("post-processing failed"),
+    ):
+        with pytest.raises(RuntimeError, match="post-processing failed"):
+            await processor.execute_task(
+                [valid_article], "brief", output_to_console=False
+            )
+
+    repository.update_run_status.assert_any_call(
+        123, "failed", "post-processing failed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_task_preserves_stream_callback(
+    processor_dependencies, valid_article
+):
+    processor, client, _ = processor_dependencies
+    processor.stream = True
+    chunks = []
+
+    async def generate_with_chunks(*args, stream_callback=None, **kwargs):
+        stream_callback("first")
+        stream_callback(" second")
+        return _core_result()
+
+    client.generate.side_effect = generate_with_chunks
+
+    await processor.execute_task(
+        [valid_article],
+        "brief",
+        output_to_console=False,
+        stream_callback=chunks.append,
+    )
+
+    assert chunks == ["first", " second"]
+
+
+@pytest.mark.asyncio
+async def test_process_mds_translates_provider_failure_to_legacy_tuple(
+    processor_dependencies, valid_article
+):
+    processor, client, repository = processor_dependencies
+    client.generate_response.side_effect = ConnectionError(
+        "provider unavailable"
+    )
+
+    result = await processor.process_mds(
+        [valid_article], "brief", output_to_console=False
+    )
+
+    assert result == (False, 123)
+    repository.update_run_status.assert_any_call(
+        123,
+        "failed",
+        "Failed to connect to LLM service: provider unavailable",
+    )
+    client.generate.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -728,7 +728,7 @@ requires-dist = [
     { name = "html2text" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "jinja2" },
-    { name = "llm-exec-core", editable = "../llm-exec-core" },
+    { name = "llm-exec-core", url = "https://github.com/lanmogu98/llm-exec-core/releases/download/0.4.1/llm_exec_core-0.4.1-py3-none-any.whl" },
     { name = "markitdown", extras = ["all"] },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -1075,12 +1075,15 @@ wheels = [
 [[package]]
 name = "llm-exec-core"
 version = "0.4.1"
-source = { editable = "../llm-exec-core" }
+source = { url = "https://github.com/lanmogu98/llm-exec-core/releases/download/0.4.1/llm_exec_core-0.4.1-py3-none-any.whl" }
 dependencies = [
     { name = "httpx" },
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pyyaml" },
+]
+wheels = [
+    { url = "https://github.com/lanmogu98/llm-exec-core/releases/download/0.4.1/llm_exec_core-0.4.1-py3-none-any.whl", hash = "sha256:30dbc41afa29cf1e74d572703a93111f65ab7581eae4d69d739fe292d007e6f7" },
 ]
 
 [package.metadata]
@@ -1089,17 +1092,6 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pyyaml" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "black", specifier = ">=23.0.0" },
-    { name = "flake8", specifier = ">=6.0.0" },
-    { name = "mypy", specifier = ">=1.0.0" },
-    { name = "pytest", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.21.0" },
-    { name = "types-jsonschema", specifier = ">=4.26.0.20260518" },
-    { name = "types-pyyaml" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #34

Maintainer dispatch: https://github.com/lanmogu98/editor-assistant/issues/34#issuecomment-5043996844

Core design prerequisite: #27, merged as `32dc392f38da1e54fdf6ac6e4bf069a9d397710b`.

## What changed

- consume the reviewed `llm-exec-core` 0.4.1 release wheel directly and lock SHA-256 `30dbc41afa29cf1e74d572703a93111f65ab7581eae4d69d739fe292d007e6f7`, removing the sibling editable source;
- add JSON-aware `OutputArtifact` and success-only `TaskExecutionResult`;
- add `MDProcessor.execute_task()`, preserving the original core `LLMResult` (text, structured value, typed usage, and planning metadata);
- keep `process_mds()` on the legacy `generate_response()` adapter and retain `process_multiple()` return/callback behavior;
- add focused tests and directly related Python API/dependency docs.

## Compatibility and scope

- Existing `brief`, `outline`, and `translate` prompts and text outputs are unchanged and are surfaced as `text/plain` artifacts.
- Existing streaming callback behavior and mocked `generate_response()` callers remain supported.
- Typed validation/provider/post-processing failures propagate; the legacy wrapper translates failures to its existing `(False, run_id)` result.
- No CLI schema flags or JSON stdout, generic structured extraction, persistence redesign, automatic classification, task prompt changes, or #35/#36 work is included.
- Provider HTTP was mocked/faked; no live provider calls or credentials were used.

## Validation

Exact head: `8a1e439a67e13440c6d2ffdc980f974bb9b38e3c`

- `uv lock --check` — passed
- `uv run --frozen black --target-version py310 --check src/ tests/` — 54 files unchanged
- `uv run --frozen flake8 src/` — passed
- `uv run --frozen mypy src/` — 24 source files passed
- unit suite with provider keys unset — 190 passed
- integration suite with provider keys unset — 6 passed, 18 skipped
- sdist and wheel build — passed
- independent read-only exact-head review — **PASS**, no Critical/Important/Minor findings
- remote delivery snapshot — branch and PR head both `8a1e439a67e13440c6d2ffdc980f974bb9b38e3c`; PR is mergeable; this repository has no workflow definitions, and GitHub reports zero commit-status contexts and zero PR-triggered workflow runs

A diagnostic umbrella `pytest -q` also reached 196 passed and 19 skipped; its five failures are the pre-existing stress tests that instantiate removed catalog model `deepseek-v3.2`. This PR changes neither the stress tests nor the model catalog, and the independent reviewer confirmed the mismatch exists at the base commit.

## Risk and rollback

The typed entry is additive. Reverting this PR restores the prior dependency source and removes the new typed API while leaving the established task, CLI, and persistence contracts otherwise unchanged.