### PR TITLE
docs: define PyPI release reliability project

### DIFF
--- a/docs/superpowers/specs/2026-07-23-cross-repo-release-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-23-cross-repo-release-reliability-design.md
@@ -1,271 +1,444 @@
 # Reliable Core Releases & Editor Dependency Delivery
 
-**Status:** accepted design; implementation not authorized by this document
-
-**Date:** 2026-07-23
+**Status:** accepted design; audited 2026-07-23; implementation not authorized
 
 **Program Epic:** [editor-assistant#38](https://github.com/lanmogu98/editor-assistant/issues/38)
 
 **GitHub Project:** [Reliable Core Releases & Editor Dependency Delivery](https://github.com/users/lanmogu98/projects/11)
 
-## Purpose
+## Purpose and authority
 
-Create a reproducible cross-repository delivery path in which `llm-exec-core`
-publishes validated Python artifacts through GitHub Releases and
-`editor-assistant` consumes, tests, and proposes upgrades to those immutable
-artifacts without following the Core `main` branch.
+Create a reproducible cross-repository delivery path in which
+`llm-exec-core` publishes validated, immutable Python artifacts through GitHub
+Releases and `editor-assistant` consumes, tests, and proposes upgrades to those
+artifacts without following Core `main`.
 
-This is a planning contract. Creating the Project, Epic, child Issues, and this
-document does not authorize workflow implementation, repository-setting
-changes, releases, pull requests, merges, secrets, bypasses, or direct updates
-to `main`. Each implementation Issue requires a later explicit dispatch.
+This document, the Project, and its Issues are planning contracts. They do not
+authorize workflow implementation, repository-setting changes, releases,
+pull requests, merges, secrets, approvals, bypasses, or direct updates to
+`main`. Every child needs a later explicit dispatch for its exact actor, scope,
+branch/PR delivery, and any separately withheld owner action.
 
-## Current state and problem
+## Audited current state
 
-- `llm-exec-core` is currently version `0.4.1` and already has an offline CI
-  workflow for Python 3.10 and 3.13, but no automated GitHub Release workflow.
-- `editor-assistant` declares `llm-exec-core>=0.4.1,<0.5.0`, then overrides it
-  with an editable sibling path in `[tool.uv.sources]`:
-  `../llm-exec-core`.
-- A clean Editor checkout therefore cannot reproduce the dependency without a
-  particular local directory layout.
-- Editor has no CI workflow and no active `main` protection tied to real check
-  names.
-- Core changes frequently enough that relying on a maintainer to notice every
-  Release and edit Editor manually is not a dependable update mechanism.
+- Core `main` is version `0.4.1`; its version also appears in
+  `llm_exec_core.__version__`, the root `uv.lock` package entry, and version
+  assertions.
+- Core tags use bare versions such as `0.4.1`, not `v0.4.1`.
+- Core has locked, provider-offline CI on Python 3.10 and 3.13, but no Release
+  workflow. Its required checks are `CI / python-3.10` and
+  `CI / python-3.13`.
+- Existing Release `0.4.1` predates this program. GitHub Release immutability
+  applies only to future Releases, so `0.4.1` is not an eligible Editor
+  artifact.
+- Editor declares `llm-exec-core>=0.4.1,<0.5.0`, then overrides it with the
+  editable sibling path `../llm-exec-core` in `[tool.uv.sources]`; `uv.lock`,
+  `README.md`, and `DEVELOPER_GUIDE.md` encode that local layout.
+- Editor has no CI workflow and no active `main` Ruleset tied to real checks.
+- The 2026-07-23 local feasibility baseline on Python 3.13 completed
+  `uv sync --locked`, 183 unit tests, Black, Flake8, and mypy successfully.
+  Python 3.10 remains a required real CI result.
+
+"Provider-offline" means tests perform no provider/live/paid LLM calls and
+receive no provider credentials. Runner bootstrap still downloads declared
+package and Release artifacts over HTTPS.
 
 ## Accepted decisions
 
-1. Publish Core distributions through GitHub Releases, not PyPI.
-2. Build wheel and sdist from an exact versioned source commit and tag.
-3. Editor consumes an immutable Release wheel URL and never follows Core
-   `main`.
-4. Stable releases below `0.5.0` are eligible for routine update PRs.
-5. `0.5.0` and later require an explicit compatibility assessment and are not
-   adopted automatically.
-6. Generated dependency PRs never auto-merge.
-7. Required Editor CI is offline and uses no provider API keys or paid LLM
-   calls.
-8. Editor `main` uses a solo-maintainer-friendly Ruleset: PR required, zero
-   approvals required, real checks required and current, conversations
-   resolved, force pushes and deletion blocked, and no default administrator
-   bypass.
+1. Publish Core distributions through public GitHub Releases, not PyPI.
+2. Core tags are exact normalized PEP 440 versions without a `v` prefix.
+3. Enable GitHub Release immutability before any program Release. Convention,
+   checksums, and an unmoved tag are not substitutes for the platform control.
+4. Build wheel and sdist from one exact reviewed `main` commit and verify all
+   intentional version loci plus distribution metadata.
+5. Editor consumes one immutable Release wheel through a PEP 508 HTTPS URL
+   ending in `#sha256=<verified-wheel-digest>`; it never follows Core `main`.
+6. The GitHub asset digest, `SHA256SUMS`, downloaded bytes, URL fragment,
+   wheel metadata, package `__version__`, Release tag, and tag target must
+   agree.
+7. Stable immutable Releases below `0.5.0` are eligible for routine update
+   PRs. Crossing `0.5.0` opens one boundary-keyed compatibility assessment and
+   never changes the dependency automatically.
+8. Generated dependency PRs are neither approved nor auto-merged.
+9. Editor CI exposes three stable checks and executes candidate code only with
+   a read-only token.
+10. Editor `main` uses a solo-maintainer Ruleset with zero approvals, strict
+    GitHub-Actions-sourced checks, resolved conversations, no force/delete,
+    and no bypass actor.
+11. Repository default `GITHUB_TOKEN` permissions stay read-only. Release
+    immutability and Actions-created-PR capability are explicit, separate
+    owner-setting prerequisites rather than hidden workflow assumptions.
+12. Updater production mutation is additionally gated by the repository
+    variable `LLM_EXEC_CORE_UPDATER_ENABLED`. It remains absent or `false`
+    through #44 and is enabled only inside the explicitly dispatched #43
+    rehearsal, preventing scheduled runs from mutating state between gates.
 
 ## Program structure and dependency order
 
-The GitHub Project contains the Epic plus seven implementation/validation
-contracts. Its numeric `Sequence` field is persisted and sorted ascending.
+GitHub native parent/sub-issue and blocked-by relations are the dependency
+source of truth. Project `Sequence` mirrors them and is sorted ascending.
 
-| Sequence | Repository | Contract | Depends on | Required result |
-|---:|---|---|---|---|
+| Sequence | Repository | Contract | Depends on | Observable result |
+| ---: | --- | --- | --- | --- |
 | 0 | Editor | [Epic #38](https://github.com/lanmogu98/editor-assistant/issues/38) | — | Program coordination and final acceptance |
-| 1 | Core | [#39](https://github.com/lanmogu98/llm-exec-core/issues/39) | Existing Core CI | Controlled, validated Release workflow |
-| 2 | Core | [#40](https://github.com/lanmogu98/llm-exec-core/issues/40) | Core #39 | First legitimate workflow-produced stable Release |
-| 3 | Editor | [#39](https://github.com/lanmogu98/editor-assistant/issues/39) | Core #40 | Immutable Release dependency and regenerated lock |
-| 4 | Editor | [#40](https://github.com/lanmogu98/editor-assistant/issues/40) | Editor #39 | Stable quality and Python compatibility checks |
-| 5 | Editor | [#41](https://github.com/lanmogu98/editor-assistant/issues/41) | Editor #40 | Active `main` Ruleset using observed check names |
-| 6 | Editor | [#42](https://github.com/lanmogu98/editor-assistant/issues/42) | Editor #41 | Compatible-Release updater that opens CI-gated PRs |
-| 7 | Editor | [#43](https://github.com/lanmogu98/editor-assistant/issues/43) | Editor #42 | Recorded end-to-end production rehearsal |
+| 1 | Core | [#39](https://github.com/lanmogu98/llm-exec-core/issues/39) | Existing Core CI | Reviewed Release workflow and post-merge dry run |
+| 2 | Core | [#41](https://github.com/lanmogu98/llm-exec-core/issues/41) | Core #39 | Future Releases made immutable by owner setting |
+| 3 | Core | [#42](https://github.com/lanmogu98/llm-exec-core/issues/42) | Core #41 | Legitimate compatible version commit on `main` |
+| 4 | Core | [#40](https://github.com/lanmogu98/llm-exec-core/issues/40) | Core #42 | First immutable workflow-produced stable Release |
+| 5 | Editor | [#39](https://github.com/lanmogu98/editor-assistant/issues/39) | Core #40 | Hash-bearing immutable dependency and lock |
+| 6 | Editor | [#40](https://github.com/lanmogu98/editor-assistant/issues/40) | Editor #39 | Stable quality and Python compatibility checks |
+| 7 | Editor | [#41](https://github.com/lanmogu98/editor-assistant/issues/41) | Editor #40 | Active `main` Ruleset using observed check names |
+| 8 | Editor | [#42](https://github.com/lanmogu98/editor-assistant/issues/42) | Editor #41 | Reviewed updater and non-mutating post-merge dry run |
+| 9 | Editor | [#44](https://github.com/lanmogu98/editor-assistant/issues/44) | Editor #42 | PR switch enabled while mutation stays inactive |
+| 10 | Editor | [#43](https://github.com/lanmogu98/editor-assistant/issues/43) | Editor #44 | Controlled activation and production rehearsal |
 
 ```mermaid
 flowchart LR
-    C1["Core #39<br/>Release workflow"] --> C2["Core #40<br/>First legitimate Release"]
-    C2 --> E1["Editor #39<br/>Immutable dependency"]
-    E1 --> E2["Editor #40<br/>Offline CI"]
+    C1["Core #39<br/>Release workflow"] --> C2["Core #41<br/>Immutable Releases"]
+    C2 --> C3["Core #42<br/>Version preparation"]
+    C3 --> C4["Core #40<br/>First immutable Release"]
+    C4 --> E1["Editor #39<br/>Immutable dependency"]
+    E1 --> E2["Editor #40<br/>Provider-offline CI"]
     E2 --> E3["Editor #41<br/>main Ruleset"]
-    E3 --> E4["Editor #42<br/>Update PR automation"]
-    E4 --> E5["Editor #43<br/>End-to-end rehearsal"]
+    E3 --> E4["Editor #42<br/>Updater implementation"]
+    E4 --> E5["Editor #44<br/>Actions PR setting"]
+    E5 --> E6["Editor #43<br/>Activation + rehearsal"]
 ```
 
-No child starts before its predecessor is complete. The Epic closes only after
-the sequence-7 rehearsal has passed and its evidence is recorded.
+No child starts before its native blocker closes. The Epic closes only after
+sequence 10 passes and its evidence is recorded.
 
-## Architecture
+## Contract details
 
-### 1. Core Release workflow
+### 1. Core Release workflow — Core #39
 
-Core #39 adds one controlled Release workflow, expected at
-`.github/workflows/release.yml`.
+Add `.github/workflows/release.yml`, manually dispatched with exact `version`
+and Boolean `dry_run` inputs. It must:
 
-The workflow is manually dispatched with an exact version and a dry-run/publish
-mode. It must:
+1. run only for the dispatched current `main` SHA;
+2. use a bare no-`v` tag;
+3. match input, `pyproject.toml`, `llm_exec_core.__version__`, the root
+   `uv.lock` entry, wheel/sdist metadata, and intended tag;
+4. reject non-normalized input and existing tags/Releases/assets before
+   mutation;
+5. run Core's canonical locked gates on Python 3.10 and 3.13;
+6. build wheel and sdist once, then clean-install each distribution separately
+   on both Pythons with import/metadata/version assertions;
+7. generate `SHA256SUMS`;
+8. upload ordinary workflow artifacts only in dry-run mode;
+9. in publish mode, create the tag and draft, attach the complete assets,
+   publish, then read back tag target, asset digests, and `immutable: true`;
+10. serialize release attempts without cancelling an in-flight publish.
 
-1. run only against the intended `main` commit;
-2. require the input version to equal `project.version` in `pyproject.toml`;
-3. require the corresponding `vX.Y.Z` tag and public Release not to exist;
-4. run the canonical locked CI gates already used by Core;
-5. build wheel and sdist with `uv build`;
-6. install the built wheel in clean Python 3.10 and 3.13 environments and run
-   a minimal import/version smoke test;
-7. generate a `SHA256SUMS` file for both distributions;
-8. in dry-run mode, upload only workflow artifacts and create no tag or
-   Release; and
-9. in publish mode, create the exact tag, stage a draft Release, upload the
-   wheel, sdist, and checksums, then publish only after every preceding gate
-   succeeds.
+Actions are full-SHA pinned. Defaults are read-only; only the publication job
+gets `contents: write`. No provider key, PAT, live call, untrusted PR code, or
+`pull_request_target` is allowed.
 
-The workflow uses concurrency control to prevent overlapping releases. Actions
-are pinned to immutable commit SHAs. Default permissions are read-only;
-`contents: write` is scoped only to the publishing job.
+`workflow_dispatch` only receives events after the workflow exists on the
+default branch. Therefore the implementation PR first passes existing CI and
+independent exact-head review, the maintainer merges, and then a dry run on the
+resulting `main` SHA closes #39. A failure requires a repair PR. #39 creates no
+stable Release.
 
-Release assets are append-only from the program's perspective. A bad public
-artifact is never overwritten under an existing tag. It is documented and
-superseded by a new patch Release.
+### 2. Release immutability — Core #41
 
-Core #39 proves the workflow in dry-run mode but does not invent a stable
-version merely to finish the Issue. Core #40 performs the next legitimate
-stable Release after the change set and version are independently justified.
+After #39's dry run, the maintainer enables **Settings → General → Releases →
+Enable release immutability**. UI and
+`GET /repos/lanmogu98/llm-exec-core/immutable-releases` must read back enabled.
+The Issue records the prior state, retrieval date, and owner-enforcement state.
 
-### 2. Immutable Editor dependency
+This Issue creates no tag or Release and changes no workflow permission.
+Existing `0.4.1` remains mutable/ineligible because the setting is prospective.
 
-Editor #39 removes the editable sibling source and replaces the dependency with
-a standard PEP 508 direct reference to the validated wheel, for example:
+### 3. Legitimate version preparation — Core #42
+
+Prepare one focused version-only PR after release-worthy product changes are
+already reviewed on `main`. The version must be stable, newer than `0.4.1`,
+below `0.5.0`, absent from tags/Releases, and justified by compatibility impact.
+
+The bounded surface is `project.version`, `llm_exec_core.__version__`, the root
+package version in `uv.lock`, direct version assertions, and minimal
+changelog/release-note preparation. Refreshing the lock may change only that
+root version; third-party versions, sources, and hashes remain identical.
+Runtime, catalog, schema, dependency, workflow, and unrelated lock changes are
+excluded. The PR passes `uv lock --check`, canonical CI, and independent
+review; it creates no Release or tag. If no legitimate compatible version is
+ready, the program waits.
+
+### 4. First immutable Release — Core #40
+
+On Core #42's exact merged `main` SHA, run dry-run and then owner-dispatched
+publish mode. Record:
+
+- source SHA, no-`v` tag, tag target, Release/run URLs;
+- agreeing Core `pyproject.toml`, `__version__`, root `uv.lock`, and
+  distribution versions;
+- `immutable: true` and successful Release-attestation verification;
+- wheel, sdist, `SHA256SUMS`, GitHub asset digests, and matching local hashes;
+- generated notes range; and
+- Python 3.10/3.13 clean-install, import, and version evidence for both wheel
+  and sdist.
+
+The consumer URL must support appending `#sha256=<wheel digest>`. A public bad
+Release is preserved and superseded; it is never rewritten.
+
+### 5. Immutable Editor dependency — Editor #39
+
+Replace the range plus sibling override with:
 
 ```toml
-"llm-exec-core @ https://github.com/lanmogu98/llm-exec-core/releases/download/vX.Y.Z/llm_exec_core-X.Y.Z-py3-none-any.whl"
+"llm-exec-core @ https://github.com/lanmogu98/llm-exec-core/releases/download/X.Y.Z/llm_exec_core-X.Y.Z-py3-none-any.whl#sha256=<verified-wheel-digest>"
 ```
 
-`uv.lock` is regenerated and committed. The Release tag, wheel filename,
-package metadata version, and locked artifact hash must agree.
+Regenerate `uv.lock` without a global upgrade. Lock changes must be limited to
+the Editor root requirement, Core, and dependency-closure changes required by
+the new Core metadata; unrelated locked versions, sources, and hashes remain
+unchanged. Update both languages in `README.md`, the stale sibling and `0.1.0`
+instructions in `DEVELOPER_GUIDE.md`, and the existing dependency contract
+tests. Those tests parse the direct URL/version/hash, reject local sources, and
+enforce a stable pin below `0.5.0`; crossing the boundary requires an explicit
+assessment plus an intentional policy-test change. Validate from clean
+no-sibling checkouts with:
 
-A direct reference is already an exact pin, so PEP 508 does not combine it with
-`<0.5.0` on the same requirement. The `0.5.0` ceiling is instead a hard policy
-gate in the updater: it may rewrite the exact URL only when the candidate
-version is stable and `<0.5.0`. Before updater automation exists, the exact URL
-itself prevents unplanned movement.
+- `uv sync --locked`;
+- `uv run --frozen pytest tests/unit/`;
+- `uv build` plus Editor wheel metadata inspection; and
+- `pip install .` and public-import/version smoke tests on Python 3.10/3.13.
 
-Acceptance requires both `uv` and ordinary `pip` installation from a clean
-checkout without a sibling Core repository, on Python 3.10 and 3.13.
+The updater owns the `<0.5.0` policy; a direct URL cannot carry a simultaneous
+range specifier.
 
-### 3. Editor CI contract
+### 6. Editor CI — Editor #40
 
-Editor #40 adds `.github/workflows/ci.yml`, triggered for every pull request to
-`main`, every push to `main`, and manual dispatch. It has no path filters and
-uses read-only permissions.
+Add `.github/workflows/ci.yml` for every PR to `main`, push to `main`, and
+manual dispatch, with no path or commit skip. Pin uv and all Actions; run
+`uv sync --locked`, then frozen commands. Default permission is
+`contents: read`.
 
-The required check names are stable contracts:
+Stable job/check names:
 
-- `Quality`
-- `Unit tests (Python 3.10)`
-- `Unit tests (Python 3.13)`
+- `Quality` — Python 3.13; Black on `src/ tests/`, Flake8 on `src/`, mypy on
+  `src/`;
+- `Unit tests (Python 3.10)` — full `tests/unit/`;
+- `Unit tests (Python 3.13)` — the same suite.
 
-`Quality` runs on Python 3.13 and checks Black formatting, Flake8 linting, and
-mypy typing using the repository's documented scopes. Unit jobs run only
-`tests/unit/` with the frozen lockfile. Integration tests, provider credentials,
-network LLM calls, and paid calls are excluded.
+The matrix uses `fail-fast: false`. Integration/stress/live/paid tests and
+provider credentials are excluded. A baseline problem becomes a focused
+blocker instead of a weakened check or hidden cleanup.
 
-If the existing baseline fails one of these commands, Editor #40 fixes only a
-small blocker that is directly necessary to establish the check. Larger cleanup
-is split into a focused follow-up Issue rather than hidden inside CI work.
+### 7. `main` Ruleset — Editor #41
 
-### 4. `main` Ruleset
+After recent real checks exist, create active `Protect main` targeting `main`:
 
-Editor #41 creates an active Ruleset named `Protect main` only after #40 has
-produced real check runs. It targets `main` and requires:
+- PR required, 0 approvals, conversations resolved;
+- all three exact checks required from the GitHub Actions expected source;
+- branch current with `main` before merge;
+- force push and deletion blocked;
+- no bypass actor.
 
-- changes through a pull request;
-- zero required approvals;
-- all review conversations resolved;
-- the exact three checks above;
-- the branch to be current with `main` before merge;
-- no force pushes; and
-- no branch deletion.
+Signed commits, linear history, deployments, code owners, auto-merge, and
+unrelated gates stay off. A safe PR proves pending/current-head enforcement;
+force/delete controls are verified by readback, not destructive tests.
 
-There is no default administrator bypass. Signed commits, linear history,
-deployment gates, and unrelated restrictions are out of scope.
+### 8. Compatible Release updater — Editor #42
 
-### 5. Compatible Release updater
+Add:
 
-Editor #42 adds `.github/workflows/update-llm-exec-core.yml`, scheduled daily and
-available through `workflow_dispatch`.
+- `.github/workflows/update-llm-exec-core.yml`;
+- `scripts/update_llm_exec_core.py` for deterministic PEP 440 selection,
+  integrity validation, and rewrite planning;
+- `tests/unit/test_update_llm_exec_core.py` with offline fixtures; and
+- an explicit `packaging` development dependency plus lock update.
 
-For each run it:
+The updater runs daily and by manual dry run, with one concurrency group. A
+write-capable path runs only when repository variable
+`LLM_EXEC_CORE_UPDATER_ENABLED` is exactly `true`. When the variable is absent
+or false, scheduled and non-dry-run invocations stop after read-only discovery
+and create no branch, PR, assessment Issue, or dependency-file mutation. Every
+updater invocation must use the workflow and source ref from current `main`;
+another ref fails before a write-capable job can start. It:
 
-1. queries public Releases in `lanmogu98/llm-exec-core`;
-2. ignores drafts, prereleases, invalid tags, and Releases missing the expected
-   wheel or checksum evidence;
-3. determines the exact currently pinned Core version from `pyproject.toml`;
-4. selects only a newer stable candidate below `0.5.0`;
-5. verifies that Release/tag/artifact versions and the published SHA256 entry
-   agree;
-6. updates the direct wheel URL and regenerates `uv.lock`;
-7. reuses one deterministic branch/PR for the candidate version; and
-8. includes old/new versions, Release notes, Release URL, artifact URL, and
-   checksum evidence in the PR body.
+1. paginates public Releases and parses versions with `packaging.version`;
+2. selects the greatest newer stable public version below `0.5.0` before any
+   integrity filtering, then requires that exact Release to be immutable and
+   complete;
+3. independently detects the `0.5.0` boundary, even in the same run;
+4. requires the wheel, sdist, checksum file, attestation, tag provenance,
+   `immutable: true`, and agreeing GitHub/file/download digests;
+5. fails rather than falling back when that greatest version is mutable,
+   malformed, incomplete, or internally inconsistent;
+6. rewrites the hash-bearing URL, performs a minimal non-global lock update,
+   checks it, enforces a two-file diff allowlist, and rejects lock changes
+   outside the Editor/Core dependency closure;
+7. owns one branch, `automation/update-llm-exec-core`, and at most one active
+   same-repository PR targeting `main`; an active PR advances to the greatest
+   candidate using guarded force-with-lease semantics;
+8. does not recreate a deliberately closed PR for the same candidate;
+9. keeps one assessment Issue keyed to boundary `0.5.0`; and
+10. never approves, auto-merges, bypasses, or pushes to `main`.
 
-Runs are idempotent. Repeating a run does not create duplicate PRs or duplicate
-assessment Issues. The workflow never enables auto-merge.
+Only the mutation job has `contents: write`, `pull-requests: write`,
+`issues: write`, and `actions: write`; it is conditioned on both current
+`main` and the activation variable. Candidate code is not installed or
+executed in that privileged job. Tags, filenames, notes, and API JSON are
+untrusted data and are never evaluated as shell code.
 
-For `0.5.0+`, the updater changes neither `pyproject.toml` nor `uv.lock`. It
-creates or updates one version-keyed compatibility-assessment Issue instead.
+After a generated branch/PR exists, the updater explicitly dispatches
+`.github/workflows/ci.yml` on that branch with
+`return_run_details=true`, requires the HTTP 200 response's
+`workflow_run_id`/URLs, and asserts event, branch, head SHA, and all three job
+names/results. It does not rely on the approval-required PR run generated by a
+`GITHUB_TOKEN` event or ambiguous after-the-fact run matching.
 
-The preferred credential is the repository-scoped `GITHUB_TOKEN`; no long-lived
-PAT is introduced by default. Because events created by `GITHUB_TOKEN` generally
-do not start another workflow, merely opening the PR is insufficient. The
-implementation must use and prove a secure explicit handoff, such as dispatching
-the CI workflow on the generated branch, so all three required check names are
-attached to the PR head commit. If that cannot be demonstrated, #42 remains
-blocked rather than weakening the Ruleset.
+Because the new updater also needs to exist on the default branch, #42 closes
+after its implementation PR is merged and a fixture-backed non-mutating dry run
+succeeds. Tests must prove the absent/false activation gate prevents every
+mutation and a non-`main` dispatch cannot enter the privileged job. Production
+remains inactive through #44.
 
-### 6. End-to-end rehearsal
+### 9. Actions-created PR setting — Editor #44
 
-Editor #43 uses the next legitimate compatible Core Release and records:
+After reviewing every workflow permission, the maintainer enables **Allow
+GitHub Actions to create and approve pull requests** while retaining read-only
+default workflow permissions. The combined GitHub switch does not authorize
+this workflow to approve anything; no approval or auto-merge code is present.
+The activation variable remains absent or `false`, so this setting gate cannot
+race a schedule into a production branch, PR, or assessment Issue.
 
-- Core Release workflow run, tag, Release, assets, and checksums;
-- updater run and generated Editor PR;
-- all three required checks on the PR head;
-- observed Ruleset refusal while a required check is absent/failing;
-- manual merge after all requirements pass;
-- the merge commit and green post-merge `main` run; and
-- a rollback-through-PR path to the previous validated Release.
+UI, `GET /repos/lanmogu98/editor-assistant/actions/permissions/workflow`, and
+`GET /repos/lanmogu98/editor-assistant/actions/variables` must agree. This
+setting-only Issue creates no PR and introduces no PAT, App key, deploy key, or
+provider secret. #43 owns changing `LLM_EXEC_CORE_UPDATER_ENABLED` to `true`,
+reading it back through the named-variable endpoint, and the first production
+run.
 
-The `0.5.0+` branch is rehearsed with read-only/dry-run fixture input. The
-program does not publish a fake stable Release merely to complete validation.
+### 10. Production rehearsal — Editor #43
+
+Use a later legitimate stable Core Release below `0.5.0`—not the initial
+Release already pinned by Editor #39. After all preconditions are re-read, the
+maintainer changes `LLM_EXEC_CORE_UPDATER_ENABLED` from absent/false to `true`,
+records UI and
+`GET /repos/lanmogu98/editor-assistant/actions/variables/LLM_EXEC_CORE_UPDATER_ENABLED`
+readback, and from that point #43 owns either the next scheduled run or an
+explicit production dispatch. Prove:
+
+1. immutable Release and artifact evidence;
+2. updater discovery and exactly one hash-bearing dependency PR;
+3. explicit CI dispatch run ID on the exact PR head;
+4. Ruleset block while checks are pending;
+5. all three checks passing;
+6. maintainer manual merge and green post-merge `main` CI.
+
+Use read-only fixture/dry-run input for the `0.5.0+` path, including the case
+where compatible and boundary Releases coexist. Do not create a fake Release
+or fake production assessment Issue.
+
+Open a rollback PR to the preceding validated immutable URL/hash, regenerate
+the lock, and let it reach green/mergeable Ruleset state. Record evidence and
+close it unmerged unless rollback is actually needed. This exercises recovery
+without deliberately leaving `main` behind.
 
 ## Failure and rollback semantics
 
-- Missing or inconsistent Core metadata, assets, or hashes fails closed before
-  publication or before an Editor PR is opened.
-- A failed Core publish attempt may leave a draft for controlled inspection,
-  but never a partially published stable Release.
-- Closing a generated Editor PR leaves the current dependency unchanged.
-- Editor rollback pins the immediately preceding validated wheel and lockfile
-  through the same PR, CI, and Ruleset path.
-- Direct `main` pushes, Ruleset bypasses, tag reuse, and asset replacement are
+- Metadata, tag, immutability, attestation, asset, digest, or lock mismatch
+  fails closed before consumer mutation.
+- Core validation failure creates no public Release. An incomplete draft may
+  be inspected/removed only by the maintainer.
+- A bad immutable public Release is marked unsuitable and superseded by a new
+  version; tag/asset rewriting is forbidden.
+- Closing a generated Editor PR leaves the current dependency unchanged and
+  suppresses recreation for the same candidate.
+- Editor rollback uses the immediately preceding validated URL/hash through a
+  normal PR, identical CI, and the Ruleset.
+- Before updater recovery or permission rollback, set
+  `LLM_EXEC_CORE_UPDATER_ENABLED=false` first so scheduled runs become
+  read-only before any other control changes.
+- Direct `main` pushes, Ruleset bypass, tag reuse, and asset replacement are
   never recovery mechanisms.
 
 ## Security boundaries
 
-- No provider API keys or paid service credentials enter CI.
-- Workflow permissions are explicit and minimal at job level.
-- Third-party Actions are pinned to immutable commits.
-- Release discovery is read-only against a public repository.
-- Only the updater job receives the permissions needed to write its branch,
-  PR, or assessment Issue.
-- No PAT is added unless a later focused design demonstrates that the accepted
-  repository-token path cannot meet the CI-trigger contract and the maintainer
-  separately approves the secret.
+- No provider API keys, paid calls, PATs, or production environment files.
+- Defaults are read-only; write scopes exist only on the two narrowly scoped
+  publication/updater jobs.
+- All external Actions are full-SHA pinned and uv is version-pinned.
+- Candidate Core code executes only in read-only Editor CI, never in the
+  write-capable updater job.
+- Public Release metadata and notes are untrusted input.
+- Required Ruleset checks accept GitHub Actions as the expected source.
+- No credential alternative is introduced without a new focused design and
+  explicit maintainer approval.
+
+## Known distribution constraint
+
+PEP 508 direct URLs are valid for pip/uv integration, and pip accepts them when
+Editor is installed locally or from a URL. Standards-conformant indexes such as
+PyPI reject uploaded distributions whose metadata contains direct URL
+dependencies. Publishing Editor itself to PyPI is therefore out of scope and
+would require revisiting Core distribution.
 
 ## Non-goals
 
-- Publishing Core to PyPI.
-- Tracking Core `main`, a floating branch, or an unversioned asset.
-- Automatically merging dependency updates.
-- Running live integration/provider tests in required CI.
-- Expanding into Core catalog, schema, pricing, or execution-boundary work.
-- Adding signed-commit or linear-history mandates.
-- Implementing any workflow as part of this design-document change.
+- Publishing Core or Editor to PyPI in this program.
+- Tracking Core `main`, a floating tag, or an unversioned/mutable asset.
+- Bot approval, automatic merge, or Ruleset bypass.
+- Live integration/provider tests in required CI.
+- Core catalog/schema/pricing/execution-boundary work.
+- Signed-commit or linear-history mandates.
+- Implementing any workflow or changing any setting as part of this planning
+  audit.
 
 ## Program completion criteria
 
-The program is complete only when all seven child contracts close in sequence,
-the end-to-end evidence is recorded in Editor #43, and the Epic acceptance
-checklist is satisfied. Until then, the Project remains the coordination
-surface and the individual Issue is the implementation authority for its own
-bounded step.
+The program is complete only when all ten native child contracts close in
+order, Project `Sequence` agrees, Editor #43 records exact evidence, and the
+Epic #38 acceptance checklist passes. Until then, the Project is coordination;
+each child Issue is the only implementation authority for its bounded concern.
+
+## Audit corrections incorporated
+
+The 2026-07-23 audit corrected these gaps and drifts:
+
+- changed design examples from a prefixed tag placeholder to the repository's
+  actual no-`v` `X.Y.Z` contract;
+- separated Release immutability, Core version preparation, and Actions PR
+  authorization into distinct Issues;
+- required actual GitHub immutable Releases and attestations;
+- added the PEP 508 `#sha256=` fragment and multi-source digest agreement;
+- added all Core version loci and wheel/sdist metadata checks;
+- handled the default-branch-only `workflow_dispatch` constraint explicitly;
+- made dependency synchronization enforce lock consistency with
+  `uv sync --locked`;
+- clarified provider-offline versus dependency-download network access;
+- bound required checks to the GitHub Actions source;
+- specified exact-head CI dispatch/run-ID verification for bot PRs;
+- required `return_run_details=true` so the dispatched CI run is identified
+  from the HTTP 200 response rather than timing-based lookup;
+- prevented candidate-code execution in the updater's write-capable job;
+- defined greatest-version, one-active-PR, closed-candidate, concurrent-run,
+  and boundary-deduplication behavior;
+- required wheel and sdist clean-install smoke tests on both supported Pythons;
+- required minimal lock diffs and a CI-enforced below-`0.5.0` dependency
+  policy, closing global-upgrade and manual-edit bypasses;
+- added an explicit repository-variable activation gate to prevent scheduled
+  mutation between updater merge, PR authorization, and production rehearsal;
+- reconciled rollback proof with a green unmerged rollback PR; and
+- promoted native sub-issue/blocked-by relations as dependency source of truth.
 
 ## External references
 
-- [GitHub: About releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)
+- [GitHub: Immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)
+- [GitHub: Preventing changes to releases](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/establish-provenance-and-integrity/prevent-release-changes)
+- [GitHub: Release REST API](https://docs.github.com/en/rest/releases/releases)
 - [GitHub: `GITHUB_TOKEN` event behavior](https://docs.github.com/en/actions/concepts/security/github_token)
-- [uv: Project dependencies and direct sources](https://docs.astral.sh/uv/concepts/projects/dependencies/)
+- [GitHub: Triggering workflows](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow)
+- [GitHub: Workflows REST API](https://docs.github.com/en/rest/actions/workflows)
+- [GitHub: Required ruleset checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)
+- [GitHub: Managing Actions settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)
+- [GitHub: Actions variables REST API](https://docs.github.com/en/rest/actions/variables)
+- [GitHub: Adding sub-issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues)
+- [GitHub: Creating issue dependencies](https://docs.github.com/en/enterprise-cloud@latest/issues/tracking-your-work-with-issues/using-issues/creating-issue-dependencies)
+- [Python Packaging: Dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
+- [Python Packaging: Version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/)
+- [Setuptools: Dependency management](https://setuptools.pypa.io/en/stable/userguide/dependency_management.html)
+- [uv: Project dependencies](https://docs.astral.sh/uv/concepts/projects/dependencies/)

--- a/docs/superpowers/specs/2026-07-23-cross-repo-release-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-23-cross-repo-release-reliability-design.md
@@ -1,6 +1,8 @@
 # Reliable Core Releases & Editor Dependency Delivery
 
-**Status:** accepted design; audited 2026-07-23; implementation not authorized
+**Status:** accepted PyPI pivot; audited 2026-07-23; Project revision and
+Core #39 redispatch authorized; owner-controlled settings and publication
+remain separately gated
 
 **Program Epic:** [editor-assistant#38](https://github.com/lanmogu98/editor-assistant/issues/38)
 
@@ -9,206 +11,321 @@
 ## Purpose and authority
 
 Create a reproducible cross-repository delivery path in which
-`llm-exec-core` publishes validated, immutable Python artifacts through GitHub
-Releases and `editor-assistant` consumes, tests, and proposes upgrades to those
-artifacts without following Core `main`.
+`llm-exec-core` publishes validated Python distributions to public PyPI through
+GitHub OIDC Trusted Publishing, while `editor-assistant` consumes a bounded
+index dependency, locks exact files with uv, tests upgrades, and proposes
+routine compatible updates without following Core `main`.
 
-This document, the Project, and its Issues are planning contracts. They do not
-authorize workflow implementation, repository-setting changes, releases,
-pull requests, merges, secrets, approvals, bypasses, or direct updates to
-`main`. Every child needs a later explicit dispatch for its exact actor, scope,
-branch/PR delivery, and any separately withheld owner action.
+PyPI is the authoritative distribution channel for this program. A GitHub
+Release may later present release notes, but it is non-authoritative,
+non-blocking, and ignored by the Editor updater.
+
+This document, the Project, and its Issues are execution contracts. A child
+starts only after its native blockers close and its exact implementation or
+owner-action dispatch is recorded. No child implicitly authorizes a
+repository setting, PyPI setting, package publication, pull-request merge,
+bypass, approval, secret, or direct update to `main`.
 
 ## Audited current state
 
-- Core `main` is version `0.4.1`; its version also appears in
-  `llm_exec_core.__version__`, the root `uv.lock` package entry, and version
-  assertions.
-- Core tags use bare versions such as `0.4.1`, not `v0.4.1`.
-- Core has locked, provider-offline CI on Python 3.10 and 3.13, but no Release
-  workflow. Its required checks are `CI / python-3.10` and
-  `CI / python-3.13`.
-- Existing Release `0.4.1` predates this program. GitHub Release immutability
-  applies only to future Releases, so `0.4.1` is not an eligible Editor
-  artifact.
+- Core `main` is version `0.4.1`, but contains multiple reviewed changes after
+  tag `0.4.1`. The first PyPI distribution therefore needs a new legitimate
+  version rather than publishing different source under the old version.
+- Core has locked, provider-offline CI on Python 3.10 and 3.13. Its observed
+  checks are `CI / python-3.10` and `CI / python-3.13`.
+- Core has no PyPI publishing workflow, no `pypi` GitHub environment, and no
+  PyPI Trusted Publisher.
+- A read-only request to PyPI's normalized `llm-exec-core` JSON endpoint
+  returned 404 on 2026-07-23. This is evidence only, not a reservation:
+  PyPI pending publishers do not reserve names before first publication.
 - Editor declares `llm-exec-core>=0.4.1,<0.5.0`, then overrides it with the
-  editable sibling path `../llm-exec-core` in `[tool.uv.sources]`; `uv.lock`,
-  `README.md`, and `DEVELOPER_GUIDE.md` encode that local layout.
-- Editor has no CI workflow and no active `main` Ruleset tied to real checks.
-- The 2026-07-23 local feasibility baseline on Python 3.13 completed
-  `uv sync --locked`, 183 unit tests, Black, Flake8, and mypy successfully.
-  Python 3.10 remains a required real CI result.
+  editable sibling path `../llm-exec-core` in `[tool.uv.sources]`. Its lock and
+  setup documentation therefore depend on a local sibling checkout.
+- Editor has no CI workflow and no active `main` Ruleset tied to observed
+  checks.
+- The 2026-07-23 Editor feasibility baseline on Python 3.13 completed
+  `uv sync --locked`, 183 unit tests, Black, Flake8, and mypy. Python 3.10
+  remains a required real CI result.
 
-"Provider-offline" means tests perform no provider/live/paid LLM calls and
-receive no provider credentials. Runner bootstrap still downloads declared
-package and Release artifacts over HTTPS.
+"Provider-offline" means tests perform no live or paid LLM calls and receive
+no provider credentials. Runner bootstrap may download declared packages from
+PyPI over HTTPS.
 
 ## Accepted decisions
 
-1. Publish Core distributions through public GitHub Releases, not PyPI.
-2. Core tags are exact normalized PEP 440 versions without a `v` prefix.
-3. Enable GitHub Release immutability before any program Release. Convention,
-   checksums, and an unmoved tag are not substitutes for the platform control.
-4. Build wheel and sdist from one exact reviewed `main` commit and verify all
-   intentional version loci plus distribution metadata.
-5. Editor consumes one immutable Release wheel through a PEP 508 HTTPS URL
-   ending in `#sha256=<verified-wheel-digest>`; it never follows Core `main`.
-6. The GitHub asset digest, `SHA256SUMS`, downloaded bytes, URL fragment,
-   wheel metadata, package `__version__`, Release tag, and tag target must
-   agree.
-7. Stable immutable Releases below `0.5.0` are eligible for routine update
-   PRs. Crossing `0.5.0` opens one boundary-keyed compatibility assessment and
-   never changes the dependency automatically.
+1. Public PyPI, not a GitHub Release asset, is Core's authoritative Python
+   distribution channel.
+2. Publish with PyPI Trusted Publishing bound to
+   `lanmogu98/llm-exec-core`, `.github/workflows/release.yml`, and the protected
+   `pypi` environment. Store no PyPI API token.
+3. The publishing job alone gets `id-token: write`; it only downloads
+   previously validated distributions and invokes the official PyPA publish
+   action pinned to a full commit SHA.
+4. Build wheel and sdist once from one exact reviewed Core `main` SHA. Verify
+   source versions, distribution metadata, filenames, hashes, and clean
+   installs before publication.
+5. PyPI's non-reusable filenames and release provenance replace the former
+   GitHub Release immutability/App-preflight design. A bad or partial public
+   version is yanked and superseded, never replaced or reused.
+6. Editor declares a standard index requirement
+   `llm-exec-core>=FIRST_PYPI_VERSION,<0.5.0`. `uv.lock` records the exact
+   selected version, registry files, sizes, and SHA-256 hashes.
+7. Stable, non-yanked, attested releases below `0.5.0` are eligible for
+   routine lockfile PRs. Any stable release at or above `0.5.0` opens one
+   boundary assessment and never widens the dependency automatically.
 8. Generated dependency PRs are neither approved nor auto-merged.
-9. Editor CI exposes three stable checks and executes candidate code only with
-   a read-only token.
+9. Editor CI exposes three stable provider-offline checks. Candidate package
+   code executes only in read-only CI, never in the updater's write-capable
+   job.
 10. Editor `main` uses a solo-maintainer Ruleset with zero approvals, strict
-    GitHub-Actions-sourced checks, resolved conversations, no force/delete,
-    and no bypass actor.
-11. Repository default `GITHUB_TOKEN` permissions stay read-only. Release
-    immutability and Actions-created-PR capability are explicit, separate
-    owner-setting prerequisites rather than hidden workflow assumptions.
-12. Updater production mutation is additionally gated by the repository
-    variable `LLM_EXEC_CORE_UPDATER_ENABLED`. It remains absent or `false`
-    through #44 and is enabled only inside the explicitly dispatched #43
-    rehearsal, preventing scheduled runs from mutating state between gates.
+    current-head GitHub Actions checks, resolved conversations, no
+    force/delete, and no bypass actor.
+11. Core publication and Editor updater mutation each have a repository
+    variable kill switch. Both remain absent or `false` until their dedicated
+    activation issue.
+12. TestPyPI is not a prerequisite. The dry-run path validates the exact
+    distributions without creating and maintaining a second publisher
+    identity.
 
 ## Program structure and dependency order
 
 GitHub native parent/sub-issue and blocked-by relations are the dependency
-source of truth. Project `Sequence` mirrors them and is sorted ascending.
+source of truth. Project `Sequence` records dependency depth and is sorted
+ascending; equal values are intentionally parallel lanes.
 
 | Sequence | Repository | Contract | Depends on | Observable result |
 | ---: | --- | --- | --- | --- |
 | 0 | Editor | [Epic #38](https://github.com/lanmogu98/editor-assistant/issues/38) | — | Program coordination and final acceptance |
-| 1 | Core | [#39](https://github.com/lanmogu98/llm-exec-core/issues/39) | Existing Core CI | Reviewed Release workflow and post-merge dry run |
-| 2 | Core | [#41](https://github.com/lanmogu98/llm-exec-core/issues/41) | Core #39 | Future Releases made immutable by owner setting |
-| 3 | Core | [#42](https://github.com/lanmogu98/llm-exec-core/issues/42) | Core #41 | Legitimate compatible version commit on `main` |
-| 4 | Core | [#40](https://github.com/lanmogu98/llm-exec-core/issues/40) | Core #42 | First immutable workflow-produced stable Release |
-| 5 | Editor | [#39](https://github.com/lanmogu98/editor-assistant/issues/39) | Core #40 | Hash-bearing immutable dependency and lock |
-| 6 | Editor | [#40](https://github.com/lanmogu98/editor-assistant/issues/40) | Editor #39 | Stable quality and Python compatibility checks |
-| 7 | Editor | [#41](https://github.com/lanmogu98/editor-assistant/issues/41) | Editor #40 | Active `main` Ruleset using observed check names |
-| 8 | Editor | [#42](https://github.com/lanmogu98/editor-assistant/issues/42) | Editor #41 | Reviewed updater and non-mutating post-merge dry run |
-| 9 | Editor | [#44](https://github.com/lanmogu98/editor-assistant/issues/44) | Editor #42 | PR switch enabled while mutation stays inactive |
-| 10 | Editor | [#43](https://github.com/lanmogu98/editor-assistant/issues/43) | Editor #44 | Controlled activation and production rehearsal |
+| 1 | Core | [#39](https://github.com/lanmogu98/llm-exec-core/issues/39) | Existing Core CI | Reviewed Trusted Publishing workflow and post-merge dry run |
+| 2 | Core | [#41](https://github.com/lanmogu98/llm-exec-core/issues/41) | Core #39 | Protected `pypi` GitHub environment |
+| 3 | Core | [#42](https://github.com/lanmogu98/llm-exec-core/issues/42) | Core #41 | Legitimate first public PyPI version on `main` |
+| 4 | Core | [#43](https://github.com/lanmogu98/llm-exec-core/issues/43) | Core #42 | Exact pending PyPI Trusted Publisher |
+| 5 | Core | [#40](https://github.com/lanmogu98/llm-exec-core/issues/40) | Core #43 | First attested public PyPI release |
+| 6 | Editor | [#39](https://github.com/lanmogu98/editor-assistant/issues/39) | Core #40 | Bounded index requirement and exact uv lock |
+| 7 | Core | [#47](https://github.com/lanmogu98/llm-exec-core/issues/47) | Editor #39 | Next natural compatible version prepared |
+| 7 | Editor | [#40](https://github.com/lanmogu98/editor-assistant/issues/40) | Editor #39 | Stable quality and Python compatibility checks |
+| 8 | Editor | [#41](https://github.com/lanmogu98/editor-assistant/issues/41) | Editor #40 | Active `main` Ruleset using observed check names |
+| 9 | Editor | [#42](https://github.com/lanmogu98/editor-assistant/issues/42) | Editor #41 | Reviewed PyPI updater and non-mutating post-merge dry run |
+| 10 | Editor | [#44](https://github.com/lanmogu98/editor-assistant/issues/44) | Editor #42 | Actions PR switch enabled while updater stays inactive |
+| 11 | Core | [#48](https://github.com/lanmogu98/llm-exec-core/issues/48) | Core #47 and Editor #44 | Real updater-rehearsal version published |
+| 12 | Editor | [#43](https://github.com/lanmogu98/editor-assistant/issues/43) | Core #48 | Controlled activation and full production rehearsal |
 
 ```mermaid
 flowchart LR
-    C1["Core #39<br/>Release workflow"] --> C2["Core #41<br/>Immutable Releases"]
+    C1["Core #39<br/>Trusted Publishing workflow"] --> C2["Core #41<br/>Protected pypi environment"]
     C2 --> C3["Core #42<br/>Version preparation"]
-    C3 --> C4["Core #40<br/>First immutable Release"]
-    C4 --> E1["Editor #39<br/>Immutable dependency"]
+    C3 --> C4["Core #43<br/>PyPI publisher identity"]
+    C4 --> C5["Core #40<br/>First PyPI release"]
+    C5 --> E1["Editor #39<br/>Bounded index dependency"]
     E1 --> E2["Editor #40<br/>Provider-offline CI"]
+    E1 --> C6["Core #47<br/>Next compatible version"]
     E2 --> E3["Editor #41<br/>main Ruleset"]
-    E3 --> E4["Editor #42<br/>Updater implementation"]
+    E3 --> E4["Editor #42<br/>PyPI updater"]
     E4 --> E5["Editor #44<br/>Actions PR setting"]
-    E5 --> E6["Editor #43<br/>Activation + rehearsal"]
+    C6 --> C7["Core #48<br/>Rehearsal release"]
+    E5 --> C7
+    C7 --> E6["Editor #43<br/>Activation + rehearsal"]
 ```
 
-No child starts before its native blocker closes. The Epic closes only after
-sequence 10 passes and its evidence is recorded.
+No child starts before its native blocker closes. Core #47 version preparation
+and the Editor CI/updater lane can proceed in parallel after Editor #39. Core
+#48 waits for both Core #47 and Editor #44, then proceeds immediately into the
+sequence-12 rehearsal so no intervening compatible release changes its
+candidate. The Epic closes only after that convergence evidence is recorded.
 
 ## Contract details
 
-### 1. Core Release workflow — Core #39
+### 1. Trusted Publishing workflow — Core #39
 
-Add `.github/workflows/release.yml`, manually dispatched with exact `version`
-and Boolean `dry_run` inputs. It must:
+Add exactly:
 
-1. run only for the dispatched current `main` SHA;
-2. use a bare no-`v` tag;
-3. match input, `pyproject.toml`, `llm_exec_core.__version__`, the root
-   `uv.lock` entry, wheel/sdist metadata, and intended tag;
-4. reject non-normalized input and existing tags/Releases/assets before
-   mutation;
-5. run Core's canonical locked gates on Python 3.10 and 3.13;
-6. build wheel and sdist once, then clean-install each distribution separately
-   on both Pythons with import/metadata/version assertions;
-7. generate `SHA256SUMS`;
-8. upload ordinary workflow artifacts only in dry-run mode;
-9. in publish mode, create the tag and draft, attach the complete assets,
-   publish, then read back tag target, asset digests, and `immutable: true`;
-10. serialize release attempts without cancelling an in-flight publish.
+- `.github/workflows/release.yml`;
+- `.github/release-build-constraints.txt`;
+- `docs/governance/pypi-release.md`; and
+- focused governance contract tests.
 
-Actions are full-SHA pinned. Defaults are read-only; only the publication job
-gets `contents: write`. No provider key, PAT, live call, untrusted PR code, or
-`pull_request_target` is allowed.
+The workflow is manually dispatched with an exact normalized `version`, the
+40-character `expected_sha`, and a Boolean `dry_run`. It must:
 
-`workflow_dispatch` only receives events after the workflow exists on the
-default branch. Therefore the implementation PR first passes existing CI and
-independent exact-head review, the maintainer merges, and then a dry run on the
-resulting `main` SHA closes #39. A failure requires a repair PR. #39 creates no
-stable Release.
+1. reject every ref except `refs/heads/main`, require
+   `expected_sha == github.sha ==` the repository's current default-branch
+   SHA at preflight, and bind all jobs to that exact source;
+2. match the input against `pyproject.toml`,
+   `llm_exec_core.__version__`, the Core root entry in `uv.lock`, wheel and
+   sdist metadata, and expected filenames;
+3. reject a non-stable or non-normalized version and detect an already
+   published PyPI version before entering publication;
+4. run Core's canonical locked gates on Python 3.10 and 3.13;
+5. build wheel and sdist once with sources disabled, using an exact Python
+   patch version, exact uv version, and hash-locked release build constraint
+   for every isolated build-backend requirement; record those versions, then
+   separately clean-install each distribution on both supported Pythons with
+   import/metadata/version assertions;
+6. produce and retain SHA-256 evidence for both distributions;
+7. upload ordinary GitHub workflow artifacts in dry-run mode and create no
+   tag, GitHub Release, PyPI project, or package version;
+8. fail clearly before the publish job when `dry_run` is false and repository
+   variable `LLM_EXEC_CORE_PYPI_PUBLISH_ENABLED` is not exactly `true`;
+9. use environment `pypi` and grant `id-token: write` only to the minimal
+   publish job, whose only steps download the validated artifact and invoke
+   `pypa/gh-action-pypi-publish` pinned to a full SHA;
+10. leave attestations enabled and store no username, password, API token,
+    PAT, or environment secret; and
+11. serialize attempts without cancelling an in-flight publication.
 
-### 2. Release immutability — Core #41
+All other jobs and workflow defaults are read-only. No provider credential,
+live call, untrusted PR code, arbitrary ref, `pull_request_target`, dynamic
+shell evaluation, or `skip-existing` behavior is allowed.
 
-After #39's dry run, the maintainer enables **Settings → General → Releases →
-Enable release immutability**. UI and
-`GET /repos/lanmogu98/llm-exec-core/immutable-releases` must read back enabled.
-The Issue records the prior state, retrieval date, and owner-enforcement state.
+The repository's consumer-facing build-system requirement remains
+`setuptools>=64.0`, but the release build may not resolve that open range.
+`.github/release-build-constraints.txt` pins the selected backend distribution
+and its accepted hashes, and the workflow passes that file through uv's build
+constraint plus required-hash path. Governance tests reject an unconstrained
+isolated release build, a floating Python/uv version, or a backend constraint
+without hashes. This program does not claim byte-for-byte reproducibility
+across separate runs; it requires one build per run, exact within-run artifact
+reuse, a controlled builder, recorded hashes, and PyPI provenance without
+changing sdist consumers' metadata.
 
-This Issue creates no tag or Release and changes no workflow permission.
-Existing `0.4.1` remains mutable/ineligible because the setting is prospective.
+`workflow_dispatch` becomes usable only after the workflow reaches the default
+branch. The implementation PR therefore passes Core CI and exact-head review,
+is merged by the maintainer, and then completes a dry run on the resulting
+`main` SHA. #39 does not enter the protected environment and publishes
+nothing.
 
-### 3. Legitimate version preparation — Core #42
+### 2. Protected publishing environment — Core #41
 
-Prepare one focused version-only PR after release-worthy product changes are
-already reviewed on `main`. The version must be stable, newer than `0.4.1`,
-below `0.5.0`, absent from tags/Releases, and justified by compatibility impact.
+After #39's dry run, the maintainer creates GitHub environment `pypi` with:
+
+- deployment branches restricted to `main`;
+- the maintainer as required reviewer;
+- self-review prevention left off for the solo-maintainer workflow;
+- no environment secrets; and
+- no unrelated deployment rules.
+
+The Issue records prior state, UI/API readback, reviewer identity, deployment
+branch policy, and date. `LLM_EXEC_CORE_PYPI_PUBLISH_ENABLED` remains absent
+or `false`. This setting-only issue dispatches no workflow and publishes
+nothing.
+
+If the current GitHub plan cannot enforce this exact environment policy, stop
+and revise the design; do not silently weaken the gate.
+
+### 3. First PyPI version preparation — Core #42
+
+Prepare one focused version PR after release-worthy changes are already
+reviewed on `main`. Because current `main` differs from tag `0.4.1`, the
+candidate must be a new stable version greater than `0.4.1`, below `0.5.0`,
+and absent from PyPI and Core tags.
 
 The bounded surface is `project.version`, `llm_exec_core.__version__`, the root
 package version in `uv.lock`, direct version assertions, and minimal
 changelog/release-note preparation. Refreshing the lock may change only that
 root version; third-party versions, sources, and hashes remain identical.
 Runtime, catalog, schema, dependency, workflow, and unrelated lock changes are
-excluded. The PR passes `uv lock --check`, canonical CI, and independent
-review; it creates no Release or tag. If no legitimate compatible version is
-ready, the program waits.
+excluded.
 
-### 4. First immutable Release — Core #40
+The PR passes `uv lock --check`, canonical CI, and independent review. It
+creates no PyPI release, tag, GitHub Release, or setting. If no legitimate
+compatible version is ready, the program waits rather than inventing a
+version.
 
-On Core #42's exact merged `main` SHA, run dry-run and then owner-dispatched
-publish mode. Record:
+### 4. PyPI Trusted Publisher — Core #43
 
-- source SHA, no-`v` tag, tag target, Release/run URLs;
-- agreeing Core `pyproject.toml`, `__version__`, root `uv.lock`, and
-  distribution versions;
-- `immutable: true` and successful Release-attestation verification;
-- wheel, sdist, `SHA256SUMS`, GitHub asset digests, and matching local hashes;
-- generated notes range; and
-- Python 3.10/3.13 clean-install, import, and version evidence for both wheel
-  and sdist.
+Do not execute this owner action until #42 is complete and #40 has a separately
+approved, immediately available publication window. The maintainer rechecks
+that #42's recorded source SHA is still the current `main` head and normalized
+project name `llm-exec-core` is still unregistered, then creates one pending
+PyPI GitHub publisher with the exact identity:
 
-The consumer URL must support appending `#sha256=<wheel digest>`. A public bad
-Release is preserved and superseded; it is never rewritten.
+- PyPI project: `llm-exec-core`;
+- GitHub owner: `lanmogu98`;
+- repository: `llm-exec-core`;
+- workflow: `release.yml`; and
+- environment: `pypi`.
 
-### 5. Immutable Editor dependency — Editor #39
+The owning PyPI account must have verified email, two-factor authentication,
+and maintainer-controlled recovery material before registration. Record only
+the control state, never a recovery code or authentication secret.
 
-Replace the range plus sibling override with:
+Record redacted UI evidence and the registration time. Add no long-lived API
+token and no broader publisher. A pending publisher does not reserve the
+project name, so proceed directly to #40 in the same owner operation window
+rather than leaving the pending identity idle.
+
+If the name is taken or any identity field cannot be matched exactly, stop.
+Do not publish under another name, remove the environment constraint, or fall
+back to a token without a new design and explicit approval.
+
+### 5. First public PyPI release — Core #40
+
+On Core #42's exact merged `main` SHA, the maintainer:
+
+1. reruns dry-run mode for the exact version and source SHA and confirms every
+   non-mutating gate;
+2. changes `LLM_EXEC_CORE_PYPI_PUBLISH_ENABLED` from absent/false to `true`
+   and records API/UI readback;
+3. dispatches publish mode for the exact version and `main` SHA; and
+4. explicitly approves the `pypi` environment deployment.
+
+If Core `main` no longer equals #42's recorded SHA before dispatch, stop and
+return to version/source preparation. Do not publish intervening source under
+the already prepared version.
+
+After upload, read back and record:
+
+- source SHA and workflow run URL;
+- PyPI project/version URLs and normalized metadata;
+- wheel and sdist filenames, sizes, upload times, and SHA-256 digests;
+- agreement between the exact files validated and uploaded within the publish
+  run, plus agreement with all source version loci;
+- non-yanked status;
+- successful cryptographic `pypi-attestations verify pypi` verification for
+  both files, followed by Integrity API claim checks for the exact repository,
+  workflow, environment, source SHA, subject filenames, and subject digests;
+- conversion of the pending publisher to the project's normal publisher;
+- the intended PyPI owner/maintainer roster and absence of any unexpected
+  publisher identity; and
+- clean public-index installs and import/version checks for wheel and sdist
+  on Python 3.10 and 3.13.
+
+Package publication is the release. A GitHub tag or Release is optional and
+cannot be used as acceptance evidence for PyPI.
+
+### 6. Bounded Editor index dependency — Editor #39
+
+Replace the sibling override with a standard PyPI dependency:
 
 ```toml
-"llm-exec-core @ https://github.com/lanmogu98/llm-exec-core/releases/download/X.Y.Z/llm_exec_core-X.Y.Z-py3-none-any.whl#sha256=<verified-wheel-digest>"
+"llm-exec-core>=FIRST_PYPI_VERSION,<0.5.0"
 ```
 
-Regenerate `uv.lock` without a global upgrade. Lock changes must be limited to
-the Editor root requirement, Core, and dependency-closure changes required by
-the new Core metadata; unrelated locked versions, sources, and hashes remain
-unchanged. Update both languages in `README.md`, the stale sibling and `0.1.0`
-instructions in `DEVELOPER_GUIDE.md`, and the existing dependency contract
-tests. Those tests parse the direct URL/version/hash, reject local sources, and
-enforce a stable pin below `0.5.0`; crossing the boundary requires an explicit
-assessment plus an intentional policy-test change. Validate from clean
-no-sibling checkouts with:
+Use the exact Core #40 version as `FIRST_PYPI_VERSION`. Remove Core's
+`[tool.uv.sources]` path entry and regenerate `uv.lock` without a global
+upgrade. The locked Core entry must use the public PyPI registry and record
+the exact selected version plus wheel/sdist URLs, sizes, and SHA-256 hashes.
+Lock changes are limited to the Editor root requirement, Core, and dependency
+closure changes required by Core metadata; unrelated packages remain fixed.
 
+Update both languages in `README.md`, stale sibling and `0.1.0` instructions
+in `DEVELOPER_GUIDE.md`, and dependency contract tests. Tests parse the
+specifier, reject local/direct/Git/VCS sources, enforce the `<0.5.0` boundary,
+and validate the locked PyPI source/version/hashes.
+
+Validate from a clean checkout with no sibling repository:
+
+- `uv lock --check`;
 - `uv sync --locked`;
 - `uv run --frozen pytest tests/unit/`;
 - `uv build` plus Editor wheel metadata inspection; and
-- `pip install .` and public-import/version smoke tests on Python 3.10/3.13.
+- clean `pip install` plus public import/version smoke tests on Python
+  3.10 and 3.13.
 
-The updater owns the `<0.5.0` policy; a direct URL cannot carry a simultaneous
-range specifier.
+This removes the former direct-URL metadata constraint, so publishing Editor
+to an index becomes possible in principle, but remains outside this program.
 
-### 6. Editor CI — Editor #40
+### 7. Editor CI — Editor #40
 
 Add `.github/workflows/ci.yml` for every PR to `main`, push to `main`, and
 manual dispatch, with no path or commit skip. Pin uv and all Actions; run
@@ -219,226 +336,294 @@ Stable job/check names:
 
 - `Quality` — Python 3.13; Black on `src/ tests/`, Flake8 on `src/`, mypy on
   `src/`;
-- `Unit tests (Python 3.10)` — full `tests/unit/`;
+- `Unit tests (Python 3.10)` — full `tests/unit/`; and
 - `Unit tests (Python 3.13)` — the same suite.
 
 The matrix uses `fail-fast: false`. Integration/stress/live/paid tests and
 provider credentials are excluded. A baseline problem becomes a focused
-blocker instead of a weakened check or hidden cleanup.
+blocker instead of a weakened check.
 
-### 7. `main` Ruleset — Editor #41
+### 8. Editor `main` Ruleset — Editor #41
 
 After recent real checks exist, create active `Protect main` targeting `main`:
 
-- PR required, 0 approvals, conversations resolved;
-- all three exact checks required from the GitHub Actions expected source;
+- pull request required with 0 approvals and resolved conversations;
+- all three exact current-head checks required from GitHub Actions;
 - branch current with `main` before merge;
-- force push and deletion blocked;
+- force push and deletion blocked; and
 - no bypass actor.
 
 Signed commits, linear history, deployments, code owners, auto-merge, and
 unrelated gates stay off. A safe PR proves pending/current-head enforcement;
 force/delete controls are verified by readback, not destructive tests.
 
-### 8. Compatible Release updater — Editor #42
+### 9. Compatible PyPI updater — Editor #42
 
 Add:
 
 - `.github/workflows/update-llm-exec-core.yml`;
-- `scripts/update_llm_exec_core.py` for deterministic PEP 440 selection,
-  integrity validation, and rewrite planning;
-- `tests/unit/test_update_llm_exec_core.py` with offline fixtures; and
-- an explicit `packaging` development dependency plus lock update.
+- `scripts/update_llm_exec_core.py`;
+- `tests/unit/test_update_llm_exec_core.py`; and
+- only the explicit development dependency and lock changes needed by the
+  updater.
 
-The updater runs daily and by manual dry run, with one concurrency group. A
+The updater runs daily and by manual dry run with one concurrency group. A
 write-capable path runs only when repository variable
-`LLM_EXEC_CORE_UPDATER_ENABLED` is exactly `true`. When the variable is absent
-or false, scheduled and non-dry-run invocations stop after read-only discovery
-and create no branch, PR, assessment Issue, or dependency-file mutation. Every
-updater invocation must use the workflow and source ref from current `main`;
-another ref fails before a write-capable job can start. It:
+`LLM_EXEC_CORE_UPDATER_ENABLED` is exactly `true`. When absent or false,
+scheduled and non-dry-run invocations stop after read-only discovery and
+create no branch, PR, assessment Issue, or dependency-file mutation. Every
+invocation uses workflow and source code from current `main`; another ref
+fails before a write-capable job can start.
 
-1. paginates public Releases and parses versions with `packaging.version`;
-2. selects the greatest newer stable public version below `0.5.0` before any
-   integrity filtering, then requires that exact Release to be immutable and
-   complete;
-3. independently detects the `0.5.0` boundary, even in the same run;
-4. requires the wheel, sdist, checksum file, attestation, tag provenance,
-   `immutable: true`, and agreeing GitHub/file/download digests;
-5. fails rather than falling back when that greatest version is mutable,
-   malformed, incomplete, or internally inconsistent;
-6. rewrites the hash-bearing URL, performs a minimal non-global lock update,
-   checks it, enforces a two-file diff allowlist, and rejects lock changes
-   outside the Editor/Core dependency closure;
-7. owns one branch, `automation/update-llm-exec-core`, and at most one active
-   same-repository PR targeting `main`; an active PR advances to the greatest
-   candidate using guarded force-with-lease semantics;
-8. does not recreate a deliberately closed PR for the same candidate;
-9. keeps one assessment Issue keyed to boundary `0.5.0`; and
-10. never approves, auto-merges, bypasses, or pushes to `main`.
+Using PyPI JSON/Simple and Integrity APIs as untrusted input, it:
 
-Only the mutation job has `contents: write`, `pull-requests: write`,
-`issues: write`, and `actions: write`; it is conditioned on both current
-`main` and the activation variable. Candidate code is not installed or
-executed in that privileged job. Tags, filenames, notes, and API JSON are
-untrusted data and are never evaluated as shell code.
+1. reads the current exact Core version from `uv.lock` and parses versions
+   with `packaging.version`;
+2. permits HTTPS only, fixes API hosts to `pypi.org` and artifact hosts to
+   `files.pythonhosted.org`, rejects userinfo/nonstandard ports and redirects,
+   applies explicit connection/read timeouts and bounded API/artifact response
+   sizes, requires PyPI JSON and Simple JSON to agree on release inventory,
+   version, filename, URL, size, SHA-256, and yanked state, and requires
+   downloaded bytes to match those sizes and hashes;
+3. independently discovers the greatest newer stable non-yanked release below
+   `0.5.0` and whether any stable non-yanked release crosses that boundary;
+4. requires the selected compatible release to contain one expected pure
+   Python wheel and one sdist with normalized names, versions, sizes, and
+   SHA-256 digests;
+5. cryptographically verifies each downloaded file and its provenance with
+   the pinned `pypi-attestations verify pypi --repository
+   https://github.com/lanmogu98/llm-exec-core <file-url>` path, including
+   signatures, certificate chain, transparency evidence, and subject digest;
+   after cryptographic verification, it requires the Integrity route and
+   signed subject to agree on project, version, filename, and SHA-256, then
+   additionally requires claims for `.github/workflows/release.yml`,
+   environment `pypi`, and the source SHA;
+6. fails rather than falling back if the greatest otherwise eligible
+   compatible release is malformed, incomplete, unprovenanced, or internally
+   inconsistent;
+7. freezes the verified candidate snapshot, runs a targeted
+   `uv lock --upgrade-package "llm-exec-core==<candidate>"` without changing
+   the declared range, then re-parses the final lock and requires its exact
+   Core version, file URLs, sizes, and SHA-256 hashes to equal that snapshot;
+   it rejects every production diff outside `uv.lock`; the only allowed
+   package-node changes are the union of nodes reachable from Core in the old
+   and proposed lock graphs, including every marker and source variant, so
+   shared, added, and removed transitive dependencies have an unambiguous
+   closure boundary;
+8. owns branch `automation/update-llm-exec-core` and at most one active
+   same-repository PR targeting `main`; a newer candidate advances the active
+   PR with guarded force-with-lease semantics;
+9. does not recreate a deliberately closed PR for the same candidate;
+10. owns one assessment Issue keyed to boundary `>=0.5.0`; and
+11. never approves, auto-merges, bypasses, or pushes to `main`.
+
+It also checks the currently locked release. If that release or its exact
+locked files become yanked, unavailable, or lose verifiable provenance, the
+updater fails closed and creates or updates one deduplicated health Issue. A
+newer valid compatible candidate may still be proposed, but the updater never
+silently downgrades or rewrites the declared range as recovery.
+
+Discovery, network parsing, cryptographic verification, and exact lock
+planning run in a read-only job. It emits a checksummed candidate/lock plan
+bound to the exact base SHA. Only the mutation job has `contents: write`,
+`pull-requests: write`, `issues: write`, and `actions: write`; it revalidates
+the artifact digest, plan, and unchanged `main` base before applying/pushing.
+Candidate Core code is never installed, imported, or executed in that job.
+Filenames, metadata, API JSON, and package descriptions are never evaluated as
+shell code.
 
 After a generated branch/PR exists, the updater explicitly dispatches
 `.github/workflows/ci.yml` on that branch with
-`return_run_details=true`, requires the HTTP 200 response's
-`workflow_run_id`/URLs, and asserts event, branch, head SHA, and all three job
-names/results. It does not rely on the approval-required PR run generated by a
-`GITHUB_TOKEN` event or ambiguous after-the-fact run matching.
+`return_run_details=true`, requires the dispatch response's HTTP 200 run
+identity/URLs, and asserts event, branch, head SHA, all three job names, and
+results. Any `gh` CLI path is pinned to a version supporting that response
+contract. It does not rely on the PR event suppressed for
+`GITHUB_TOKEN`-created PRs or on a timing-based run search.
 
-Because the new updater also needs to exist on the default branch, #42 closes
-after its implementation PR is merged and a fixture-backed non-mutating dry run
-succeeds. Tests must prove the absent/false activation gate prevents every
-mutation and a non-`main` dispatch cannot enter the privileged job. Production
-remains inactive through #44.
+Editor #42 closes after its implementation PR is merged and a fixture-backed,
+non-mutating post-merge dry run succeeds. Tests cover absent/false activation,
+non-`main` dispatch, yanked files, missing provenance, malicious metadata,
+greatest-version failure, compatible-plus-boundary coexistence, one-PR
+idempotency, deliberately closed candidates, candidate-discovery/lock
+resolution races, cryptographically invalid provenance, hostile redirects or
+URLs, oversized/slow responses, cross-API metadata conflicts, and
+dependency-closure diff enforcement. Production remains inactive through
+#44.
 
-### 9. Actions-created PR setting — Editor #44
+### 10. Actions-created PR setting — Editor #44
 
 After reviewing every workflow permission, the maintainer enables **Allow
 GitHub Actions to create and approve pull requests** while retaining read-only
 default workflow permissions. The combined GitHub switch does not authorize
 this workflow to approve anything; no approval or auto-merge code is present.
-The activation variable remains absent or `false`, so this setting gate cannot
-race a schedule into a production branch, PR, or assessment Issue.
 
-UI, `GET /repos/lanmogu98/editor-assistant/actions/permissions/workflow`, and
-`GET /repos/lanmogu98/editor-assistant/actions/variables` must agree. This
-setting-only Issue creates no PR and introduces no PAT, App key, deploy key, or
-provider secret. #43 owns changing `LLM_EXEC_CORE_UPDATER_ENABLED` to `true`,
-reading it back through the named-variable endpoint, and the first production
-run.
+The activation variable remains absent or `false`, so this setting cannot race
+a schedule into a production mutation. UI and Actions-permissions API readback
+must agree. This setting-only Issue creates no PR and introduces no PAT, App
+key, deploy key, provider secret, or PyPI token.
 
-### 10. Production rehearsal — Editor #43
+### 11. Next compatible version — Core #47
 
-Use a later legitimate stable Core Release below `0.5.0`—not the initial
-Release already pinned by Editor #39. After all preconditions are re-read, the
-maintainer changes `LLM_EXEC_CORE_UPDATER_ENABLED` from absent/false to `true`,
-records UI and
-`GET /repos/lanmogu98/editor-assistant/actions/variables/LLM_EXEC_CORE_UPDATER_ENABLED`
-readback, and from that point #43 owns either the next scheduled run or an
-explicit production dispatch. Prove:
+After Editor #39 has locked the first PyPI release and real new Core changes
+have landed, prepare the next natural stable version above that release and
+below `0.5.0`. Core #47 repeats #42's focused version-only contract: every
+source/lock/package version agrees, the lock changes only the root version,
+the version is absent from PyPI/tags, and exact-head Core CI/build/review pass.
 
-1. immutable Release and artifact evidence;
-2. updater discovery and exactly one hash-bearing dependency PR;
-3. explicit CI dispatch run ID on the exact PR head;
-4. Ruleset block while checks are pending;
+The version may not be fabricated for the rehearsal. Core #47 is a native
+parallel child blocked by Editor #39 and blocks Core #48. It authorizes no
+publication or owner action.
+
+### 12. Updater-rehearsal publication — Core #48
+
+After both Core #47 and Editor #44 close, publish Core #47's exact
+current-`main` SHA through the already proven Trusted Publishing workflow
+under a separate maintainer dispatch and protected environment approval.
+Repeat dry-run, public-index, file hash, non-yanked, cryptographic provenance,
+publisher-claim, and Python 3.10/3.13 install evidence. A GitHub Release
+remains optional and non-authoritative.
+
+Core #48 is a second production use of the workflow, not a fake package or
+fixture. A partial/bad version follows the same yank-and-supersede rules. It
+blocks Editor #43 and must be followed immediately by that rehearsal. No other
+compatible Core publication may intervene; if one does, stop and prepare a
+fresh explicit rehearsal release rather than violating greatest-candidate
+selection.
+
+### 13. Production rehearsal — Editor #43
+
+Use the greatest eligible newer stable Core version below `0.5.0`, which at
+activation must be the just-published Core #48 version, not the initial PyPI
+version already locked by Editor #39. Editor #43 depends natively on Core #48
+(which itself depends on Editor #44) and coordinates the evidence without
+authorizing or fabricating a Core release.
+
+After all preconditions are re-read, the maintainer changes
+`LLM_EXEC_CORE_UPDATER_ENABLED` from absent/false to `true`, records exact
+readback, and owns either the next schedule or an explicit production
+dispatch. Prove:
+
+1. PyPI file hashes and exact Trusted Publisher provenance;
+2. updater discovery and exactly one lockfile-only dependency PR;
+3. explicit CI dispatch identity on the exact PR head;
+4. Ruleset block while current-head checks are pending;
 5. all three checks passing;
-6. maintainer manual merge and green post-merge `main` CI.
+6. maintainer manual merge and green post-merge `main` CI; and
+7. no dependency specifier widening and no GitHub Release dependency.
 
-Use read-only fixture/dry-run input for the `0.5.0+` path, including the case
-where compatible and boundary Releases coexist. Do not create a fake Release
-or fake production assessment Issue.
+Use offline fixtures for the `>=0.5.0` path, including compatible and boundary
+releases in the same discovery result. Do not create a fake public package
+version or fake production assessment Issue.
 
-Open a rollback PR to the preceding validated immutable URL/hash, regenerate
-the lock, and let it reach green/mergeable Ruleset state. Record evidence and
+Open a rollback PR that restores the preceding validated Core version in
+`uv.lock`, let it reach green/mergeable Ruleset state, record evidence, and
 close it unmerged unless rollback is actually needed. This exercises recovery
 without deliberately leaving `main` behind.
 
 ## Failure and rollback semantics
 
-- Metadata, tag, immutability, attestation, asset, digest, or lock mismatch
-  fails closed before consumer mutation.
-- Core validation failure creates no public Release. An incomplete draft may
-  be inspected/removed only by the maintainer.
-- A bad immutable public Release is marked unsuitable and superseded by a new
-  version; tag/asset rewriting is forbidden.
+- Source version, distribution metadata, filename, hash, provenance, registry,
+  or lock mismatch fails closed before consumer mutation.
+- Core validation failure creates no public version. A failed OIDC request
+  introduces no long-lived credential to rotate.
+- A partial, bad, or compromised PyPI version is yanked and superseded by a
+  new version. It is not deleted as recovery; existing filenames and version
+  content are never overwritten, skipped, or reused.
+- If the PyPI name is claimed before first publication, stop the program and
+  redesign; a pending publisher is not proof of reservation.
 - Closing a generated Editor PR leaves the current dependency unchanged and
   suppresses recreation for the same candidate.
-- Editor rollback uses the immediately preceding validated URL/hash through a
-  normal PR, identical CI, and the Ruleset.
-- Before updater recovery or permission rollback, set
-  `LLM_EXEC_CORE_UPDATER_ENABLED=false` first so scheduled runs become
-  read-only before any other control changes.
-- Direct `main` pushes, Ruleset bypass, tag reuse, and asset replacement are
-  never recovery mechanisms.
+- Editor rollback selects the immediately preceding validated, available
+  version through a normal lockfile PR, identical CI, and the Ruleset.
+- Before updater recovery, set
+  `LLM_EXEC_CORE_UPDATER_ENABLED=false`. Before publisher recovery, set
+  `LLM_EXEC_CORE_PYPI_PUBLISH_ENABLED=false`, then disable the environment or
+  revoke the Trusted Publisher if necessary.
+- Direct `main` pushes, Ruleset bypass, mutable dependency sources, version
+  reuse, `skip-existing`, and artifact replacement are never recovery
+  mechanisms.
 
 ## Security boundaries
 
-- No provider API keys, paid calls, PATs, or production environment files.
-- Defaults are read-only; write scopes exist only on the two narrowly scoped
-  publication/updater jobs.
+- No provider API keys, paid calls, PATs, PyPI tokens, or production
+  environment files.
+- Repository defaults are read-only. OIDC exists only in the minimal
+  protected publish job; updater write scopes exist only in its gated mutation
+  job.
 - All external Actions are full-SHA pinned and uv is version-pinned.
-- Candidate Core code executes only in read-only Editor CI, never in the
-  write-capable updater job.
-- Public Release metadata and notes are untrusted input.
-- Required Ruleset checks accept GitHub Actions as the expected source.
-- No credential alternative is introduced without a new focused design and
-  explicit maintainer approval.
-
-## Known distribution constraint
-
-PEP 508 direct URLs are valid for pip/uv integration, and pip accepts them when
-Editor is installed locally or from a URL. Standards-conformant indexes such as
-PyPI reject uploaded distributions whose metadata contains direct URL
-dependencies. Publishing Editor itself to PyPI is therefore out of scope and
-would require revisiting Core distribution.
+- The protected environment and exact PyPI publisher identity are both
+  required; neither substitutes for the other.
+- Candidate Core code executes only in read-only Editor CI.
+- PyPI API data, filenames, metadata, descriptions, and provenance documents
+  are untrusted input until parsed and verified.
+- Required Ruleset checks accept GitHub Actions as the expected source and
+  apply to the PR's current head.
+- No credential alternative or publisher broadening is introduced without a
+  focused design and explicit maintainer approval.
 
 ## Non-goals
 
-- Publishing Core or Editor to PyPI in this program.
-- Tracking Core `main`, a floating tag, or an unversioned/mutable asset.
+- Tracking Core `main`, a branch, a floating tag, or an unversioned artifact.
+- Using GitHub Releases as Editor's dependency discovery or integrity source.
+- Publishing Editor itself to PyPI.
 - Bot approval, automatic merge, or Ruleset bypass.
 - Live integration/provider tests in required CI.
 - Core catalog/schema/pricing/execution-boundary work.
 - Signed-commit or linear-history mandates.
-- Implementing any workflow or changing any setting as part of this planning
-  audit.
+- TestPyPI and a second Trusted Publisher.
+- Automatic widening across `0.5.0`.
 
 ## Program completion criteria
 
-The program is complete only when all ten native child contracts close in
-order, Project `Sequence` agrees, Editor #43 records exact evidence, and the
-Epic #38 acceptance checklist passes. Until then, the Project is coordination;
-each child Issue is the only implementation authority for its bounded concern.
+The program is complete only when all thirteen native child contracts close
+in dependency order, Project `Sequence` agrees, Editor #43 records exact
+production and rollback evidence, and Epic #38's acceptance checklist passes.
+Until then, each child Issue is the only authority for its bounded
+implementation or owner action.
 
-## Audit corrections incorporated
+## PyPI pivot corrections incorporated
 
-The 2026-07-23 audit corrected these gaps and drifts:
+The 2026-07-23 pivot removes the failure-prone direct GitHub asset path and:
 
-- changed design examples from a prefixed tag placeholder to the repository's
-  actual no-`v` `X.Y.Z` contract;
-- separated Release immutability, Core version preparation, and Actions PR
-  authorization into distinct Issues;
-- required actual GitHub immutable Releases and attestations;
-- added the PEP 508 `#sha256=` fragment and multi-source digest agreement;
-- added all Core version loci and wheel/sdist metadata checks;
-- handled the default-branch-only `workflow_dispatch` constraint explicitly;
-- made dependency synchronization enforce lock consistency with
-  `uv sync --locked`;
-- clarified provider-offline versus dependency-download network access;
-- bound required checks to the GitHub Actions source;
-- specified exact-head CI dispatch/run-ID verification for bot PRs;
-- required `return_run_details=true` so the dispatched CI run is identified
-  from the HTTP 200 response rather than timing-based lookup;
-- prevented candidate-code execution in the updater's write-capable job;
-- defined greatest-version, one-active-PR, closed-candidate, concurrent-run,
-  and boundary-deduplication behavior;
-- required wheel and sdist clean-install smoke tests on both supported Pythons;
-- required minimal lock diffs and a CI-enforced below-`0.5.0` dependency
-  policy, closing global-upgrade and manual-edit bypasses;
-- added an explicit repository-variable activation gate to prevent scheduled
-  mutation between updater merge, PR authorization, and production rehearsal;
-- reconciled rollback proof with a green unmerged rollback PR; and
-- promoted native sub-issue/blocked-by relations as dependency source of truth.
+- makes PyPI the authoritative package source and restores standard dependency
+  metadata;
+- replaces Release immutability and an Administration-reading GitHub App with
+  PyPI's non-reusable files, OIDC identity, and per-file provenance;
+- separates workflow implementation, GitHub environment protection, version
+  preparation, PyPI publisher registration, and first publication into five
+  ordered Core gates;
+- keeps the exact workflow/environment identity narrow and removes all
+  long-lived publishing credentials;
+- makes Core #43 meaningful by repurposing it from GitHub App provisioning to
+  pending Trusted Publisher registration;
+- preserves the `<0.5.0` explicit-assessment boundary while allowing routine
+  compatible lock-only PRs;
+- changes Editor's integrity SSOT from a manually copied URL fragment to
+  `uv.lock` registry file hashes plus PyPI Integrity API provenance;
+- removes every GitHub Release immutability/App prerequisite from the critical
+  path;
+- handles the pending-publisher name-race by preparing the version first and
+  registering/publishing in one owner operation window;
+- makes the real second compatible Core release an explicit two-Issue native
+  lane instead of an untracked prerequisite for the final rehearsal;
+- handles partial public uploads, yanks, and non-reusable filenames without
+  unsafe `skip-existing`; and
+- preserves activation kill switches, explicit CI dispatch, one-PR
+  idempotency, Ruleset enforcement, and rollback rehearsal.
 
 ## External references
 
-- [GitHub: Immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)
-- [GitHub: Preventing changes to releases](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/establish-provenance-and-integrity/prevent-release-changes)
-- [GitHub: Release REST API](https://docs.github.com/en/rest/releases/releases)
+- [PyPI: Creating a project with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
+- [PyPI: Publishing with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/using-a-publisher/)
+- [PyPI: Trusted Publishing security model](https://docs.pypi.org/trusted-publishers/security-model/)
+- [PyPI: Producing attestations](https://docs.pypi.org/attestations/producing-attestations/)
+- [PyPI: Integrity API](https://docs.pypi.org/api/integrity/)
+- [PyPI Help: file and filename reuse](https://pypi.org/help/)
+- [GitHub: OIDC in PyPI](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-pypi)
+- [GitHub: Deployment environments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments)
 - [GitHub: `GITHUB_TOKEN` event behavior](https://docs.github.com/en/actions/concepts/security/github_token)
 - [GitHub: Triggering workflows](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow)
-- [GitHub: Workflows REST API](https://docs.github.com/en/rest/actions/workflows)
 - [GitHub: Required ruleset checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)
-- [GitHub: Managing Actions settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)
-- [GitHub: Actions variables REST API](https://docs.github.com/en/rest/actions/variables)
-- [GitHub: Adding sub-issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues)
-- [GitHub: Creating issue dependencies](https://docs.github.com/en/enterprise-cloud@latest/issues/tracking-your-work-with-issues/using-issues/creating-issue-dependencies)
 - [Python Packaging: Dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
 - [Python Packaging: Version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/)
-- [Setuptools: Dependency management](https://setuptools.pypa.io/en/stable/userguide/dependency_management.html)
 - [uv: Project dependencies](https://docs.astral.sh/uv/concepts/projects/dependencies/)

--- a/docs/superpowers/specs/2026-07-23-cross-repo-release-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-23-cross-repo-release-reliability-design.md
@@ -1,0 +1,271 @@
+# Reliable Core Releases & Editor Dependency Delivery
+
+**Status:** accepted design; implementation not authorized by this document
+
+**Date:** 2026-07-23
+
+**Program Epic:** [editor-assistant#38](https://github.com/lanmogu98/editor-assistant/issues/38)
+
+**GitHub Project:** [Reliable Core Releases & Editor Dependency Delivery](https://github.com/users/lanmogu98/projects/11)
+
+## Purpose
+
+Create a reproducible cross-repository delivery path in which `llm-exec-core`
+publishes validated Python artifacts through GitHub Releases and
+`editor-assistant` consumes, tests, and proposes upgrades to those immutable
+artifacts without following the Core `main` branch.
+
+This is a planning contract. Creating the Project, Epic, child Issues, and this
+document does not authorize workflow implementation, repository-setting
+changes, releases, pull requests, merges, secrets, bypasses, or direct updates
+to `main`. Each implementation Issue requires a later explicit dispatch.
+
+## Current state and problem
+
+- `llm-exec-core` is currently version `0.4.1` and already has an offline CI
+  workflow for Python 3.10 and 3.13, but no automated GitHub Release workflow.
+- `editor-assistant` declares `llm-exec-core>=0.4.1,<0.5.0`, then overrides it
+  with an editable sibling path in `[tool.uv.sources]`:
+  `../llm-exec-core`.
+- A clean Editor checkout therefore cannot reproduce the dependency without a
+  particular local directory layout.
+- Editor has no CI workflow and no active `main` protection tied to real check
+  names.
+- Core changes frequently enough that relying on a maintainer to notice every
+  Release and edit Editor manually is not a dependable update mechanism.
+
+## Accepted decisions
+
+1. Publish Core distributions through GitHub Releases, not PyPI.
+2. Build wheel and sdist from an exact versioned source commit and tag.
+3. Editor consumes an immutable Release wheel URL and never follows Core
+   `main`.
+4. Stable releases below `0.5.0` are eligible for routine update PRs.
+5. `0.5.0` and later require an explicit compatibility assessment and are not
+   adopted automatically.
+6. Generated dependency PRs never auto-merge.
+7. Required Editor CI is offline and uses no provider API keys or paid LLM
+   calls.
+8. Editor `main` uses a solo-maintainer-friendly Ruleset: PR required, zero
+   approvals required, real checks required and current, conversations
+   resolved, force pushes and deletion blocked, and no default administrator
+   bypass.
+
+## Program structure and dependency order
+
+The GitHub Project contains the Epic plus seven implementation/validation
+contracts. Its numeric `Sequence` field is persisted and sorted ascending.
+
+| Sequence | Repository | Contract | Depends on | Required result |
+|---:|---|---|---|---|
+| 0 | Editor | [Epic #38](https://github.com/lanmogu98/editor-assistant/issues/38) | — | Program coordination and final acceptance |
+| 1 | Core | [#39](https://github.com/lanmogu98/llm-exec-core/issues/39) | Existing Core CI | Controlled, validated Release workflow |
+| 2 | Core | [#40](https://github.com/lanmogu98/llm-exec-core/issues/40) | Core #39 | First legitimate workflow-produced stable Release |
+| 3 | Editor | [#39](https://github.com/lanmogu98/editor-assistant/issues/39) | Core #40 | Immutable Release dependency and regenerated lock |
+| 4 | Editor | [#40](https://github.com/lanmogu98/editor-assistant/issues/40) | Editor #39 | Stable quality and Python compatibility checks |
+| 5 | Editor | [#41](https://github.com/lanmogu98/editor-assistant/issues/41) | Editor #40 | Active `main` Ruleset using observed check names |
+| 6 | Editor | [#42](https://github.com/lanmogu98/editor-assistant/issues/42) | Editor #41 | Compatible-Release updater that opens CI-gated PRs |
+| 7 | Editor | [#43](https://github.com/lanmogu98/editor-assistant/issues/43) | Editor #42 | Recorded end-to-end production rehearsal |
+
+```mermaid
+flowchart LR
+    C1["Core #39<br/>Release workflow"] --> C2["Core #40<br/>First legitimate Release"]
+    C2 --> E1["Editor #39<br/>Immutable dependency"]
+    E1 --> E2["Editor #40<br/>Offline CI"]
+    E2 --> E3["Editor #41<br/>main Ruleset"]
+    E3 --> E4["Editor #42<br/>Update PR automation"]
+    E4 --> E5["Editor #43<br/>End-to-end rehearsal"]
+```
+
+No child starts before its predecessor is complete. The Epic closes only after
+the sequence-7 rehearsal has passed and its evidence is recorded.
+
+## Architecture
+
+### 1. Core Release workflow
+
+Core #39 adds one controlled Release workflow, expected at
+`.github/workflows/release.yml`.
+
+The workflow is manually dispatched with an exact version and a dry-run/publish
+mode. It must:
+
+1. run only against the intended `main` commit;
+2. require the input version to equal `project.version` in `pyproject.toml`;
+3. require the corresponding `vX.Y.Z` tag and public Release not to exist;
+4. run the canonical locked CI gates already used by Core;
+5. build wheel and sdist with `uv build`;
+6. install the built wheel in clean Python 3.10 and 3.13 environments and run
+   a minimal import/version smoke test;
+7. generate a `SHA256SUMS` file for both distributions;
+8. in dry-run mode, upload only workflow artifacts and create no tag or
+   Release; and
+9. in publish mode, create the exact tag, stage a draft Release, upload the
+   wheel, sdist, and checksums, then publish only after every preceding gate
+   succeeds.
+
+The workflow uses concurrency control to prevent overlapping releases. Actions
+are pinned to immutable commit SHAs. Default permissions are read-only;
+`contents: write` is scoped only to the publishing job.
+
+Release assets are append-only from the program's perspective. A bad public
+artifact is never overwritten under an existing tag. It is documented and
+superseded by a new patch Release.
+
+Core #39 proves the workflow in dry-run mode but does not invent a stable
+version merely to finish the Issue. Core #40 performs the next legitimate
+stable Release after the change set and version are independently justified.
+
+### 2. Immutable Editor dependency
+
+Editor #39 removes the editable sibling source and replaces the dependency with
+a standard PEP 508 direct reference to the validated wheel, for example:
+
+```toml
+"llm-exec-core @ https://github.com/lanmogu98/llm-exec-core/releases/download/vX.Y.Z/llm_exec_core-X.Y.Z-py3-none-any.whl"
+```
+
+`uv.lock` is regenerated and committed. The Release tag, wheel filename,
+package metadata version, and locked artifact hash must agree.
+
+A direct reference is already an exact pin, so PEP 508 does not combine it with
+`<0.5.0` on the same requirement. The `0.5.0` ceiling is instead a hard policy
+gate in the updater: it may rewrite the exact URL only when the candidate
+version is stable and `<0.5.0`. Before updater automation exists, the exact URL
+itself prevents unplanned movement.
+
+Acceptance requires both `uv` and ordinary `pip` installation from a clean
+checkout without a sibling Core repository, on Python 3.10 and 3.13.
+
+### 3. Editor CI contract
+
+Editor #40 adds `.github/workflows/ci.yml`, triggered for every pull request to
+`main`, every push to `main`, and manual dispatch. It has no path filters and
+uses read-only permissions.
+
+The required check names are stable contracts:
+
+- `Quality`
+- `Unit tests (Python 3.10)`
+- `Unit tests (Python 3.13)`
+
+`Quality` runs on Python 3.13 and checks Black formatting, Flake8 linting, and
+mypy typing using the repository's documented scopes. Unit jobs run only
+`tests/unit/` with the frozen lockfile. Integration tests, provider credentials,
+network LLM calls, and paid calls are excluded.
+
+If the existing baseline fails one of these commands, Editor #40 fixes only a
+small blocker that is directly necessary to establish the check. Larger cleanup
+is split into a focused follow-up Issue rather than hidden inside CI work.
+
+### 4. `main` Ruleset
+
+Editor #41 creates an active Ruleset named `Protect main` only after #40 has
+produced real check runs. It targets `main` and requires:
+
+- changes through a pull request;
+- zero required approvals;
+- all review conversations resolved;
+- the exact three checks above;
+- the branch to be current with `main` before merge;
+- no force pushes; and
+- no branch deletion.
+
+There is no default administrator bypass. Signed commits, linear history,
+deployment gates, and unrelated restrictions are out of scope.
+
+### 5. Compatible Release updater
+
+Editor #42 adds `.github/workflows/update-llm-exec-core.yml`, scheduled daily and
+available through `workflow_dispatch`.
+
+For each run it:
+
+1. queries public Releases in `lanmogu98/llm-exec-core`;
+2. ignores drafts, prereleases, invalid tags, and Releases missing the expected
+   wheel or checksum evidence;
+3. determines the exact currently pinned Core version from `pyproject.toml`;
+4. selects only a newer stable candidate below `0.5.0`;
+5. verifies that Release/tag/artifact versions and the published SHA256 entry
+   agree;
+6. updates the direct wheel URL and regenerates `uv.lock`;
+7. reuses one deterministic branch/PR for the candidate version; and
+8. includes old/new versions, Release notes, Release URL, artifact URL, and
+   checksum evidence in the PR body.
+
+Runs are idempotent. Repeating a run does not create duplicate PRs or duplicate
+assessment Issues. The workflow never enables auto-merge.
+
+For `0.5.0+`, the updater changes neither `pyproject.toml` nor `uv.lock`. It
+creates or updates one version-keyed compatibility-assessment Issue instead.
+
+The preferred credential is the repository-scoped `GITHUB_TOKEN`; no long-lived
+PAT is introduced by default. Because events created by `GITHUB_TOKEN` generally
+do not start another workflow, merely opening the PR is insufficient. The
+implementation must use and prove a secure explicit handoff, such as dispatching
+the CI workflow on the generated branch, so all three required check names are
+attached to the PR head commit. If that cannot be demonstrated, #42 remains
+blocked rather than weakening the Ruleset.
+
+### 6. End-to-end rehearsal
+
+Editor #43 uses the next legitimate compatible Core Release and records:
+
+- Core Release workflow run, tag, Release, assets, and checksums;
+- updater run and generated Editor PR;
+- all three required checks on the PR head;
+- observed Ruleset refusal while a required check is absent/failing;
+- manual merge after all requirements pass;
+- the merge commit and green post-merge `main` run; and
+- a rollback-through-PR path to the previous validated Release.
+
+The `0.5.0+` branch is rehearsed with read-only/dry-run fixture input. The
+program does not publish a fake stable Release merely to complete validation.
+
+## Failure and rollback semantics
+
+- Missing or inconsistent Core metadata, assets, or hashes fails closed before
+  publication or before an Editor PR is opened.
+- A failed Core publish attempt may leave a draft for controlled inspection,
+  but never a partially published stable Release.
+- Closing a generated Editor PR leaves the current dependency unchanged.
+- Editor rollback pins the immediately preceding validated wheel and lockfile
+  through the same PR, CI, and Ruleset path.
+- Direct `main` pushes, Ruleset bypasses, tag reuse, and asset replacement are
+  never recovery mechanisms.
+
+## Security boundaries
+
+- No provider API keys or paid service credentials enter CI.
+- Workflow permissions are explicit and minimal at job level.
+- Third-party Actions are pinned to immutable commits.
+- Release discovery is read-only against a public repository.
+- Only the updater job receives the permissions needed to write its branch,
+  PR, or assessment Issue.
+- No PAT is added unless a later focused design demonstrates that the accepted
+  repository-token path cannot meet the CI-trigger contract and the maintainer
+  separately approves the secret.
+
+## Non-goals
+
+- Publishing Core to PyPI.
+- Tracking Core `main`, a floating branch, or an unversioned asset.
+- Automatically merging dependency updates.
+- Running live integration/provider tests in required CI.
+- Expanding into Core catalog, schema, pricing, or execution-boundary work.
+- Adding signed-commit or linear-history mandates.
+- Implementing any workflow as part of this design-document change.
+
+## Program completion criteria
+
+The program is complete only when all seven child contracts close in sequence,
+the end-to-end evidence is recorded in Editor #43, and the Epic acceptance
+checklist is satisfied. Until then, the Project remains the coordination
+surface and the individual Issue is the implementation authority for its own
+bounded step.
+
+## External references
+
+- [GitHub: About releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)
+- [GitHub: `GITHUB_TOKEN` event behavior](https://docs.github.com/en/actions/concepts/security/github_token)
+- [uv: Project dependencies and direct sources](https://docs.astral.sh/uv/concepts/projects/dependencies/)


### PR DESCRIPTION
## Summary

- records the cross-repository delivery design for publishing `llm-exec-core` through PyPI Trusted Publishing
- defines bounded `editor-assistant` locking, provider-offline CI, `main` protection, updater, and rehearsal contracts
- incorporates the independent gap/drift audit and the final 13-child native dependency DAG in Project #11

## Scope

Documentation and planning evidence only. This PR changes no workflow, dependency, setting, permission, branch protection, publisher, package, or release.

## Verification

- independent contract audit: PASS
- GitHub Project #11: 14 items, Sequence 0–12, expected Status values
- Epic #38: 13 native sub-issues
- native blocked-by graph: read back and matched the reviewed design
- `git diff --check`: pass
- repository pre-commit checks: pass

Closes no implementation issue. Program coordination: #38.